### PR TITLE
Fix for long corrpower analytic

### DIFF
--- a/src/core/conditionaltest_serial.cpp
+++ b/src/core/conditionaltest_serial.cpp
@@ -36,7 +36,7 @@ std::unique_ptr<EAbstractAnalyticBlock> ConditionalTest::Serial::execute(const E
 {
     EDEBUG_FUNC(this, block);
 
-    // crate the work and result blocks
+    // Create the work and result blocks
     const WorkBlock* workBlock {block->cast<WorkBlock>()};
     ResultBlock* resultBlock {new ResultBlock(workBlock->index(), _base->_numTests, workBlock->startpair())};
 
@@ -49,7 +49,7 @@ std::unique_ptr<EAbstractAnalyticBlock> ConditionalTest::Serial::execute(const E
     qint64 size = workBlock->size();
     Pairwise::Index index(workBlock->start());
 
-    // iterate through each pair in the matrix
+    // Iterate through each pair in the matrix.
     for ( qint64 ccmIndex = start; ccmIndex < start + size; ccmIndex++ )
     {
         // reads the first value in the ccm

--- a/src/core/corrpower.h
+++ b/src/core/corrpower.h
@@ -93,6 +93,15 @@ private:
      * The number of pairs to process in each work block.
      */
     int _workBlockSize {0};
+    /*!
+     * The total number of working blocks.
+     */
+    int _numBlocks {0};
+    /*!
+     * Holds the indexes for the first pair of each block.
+     */
+    QVector<Pairwise::Index> _blockStarts;
+
 };
 
 

--- a/src/core/corrpower_workblock.cpp
+++ b/src/core/corrpower_workblock.cpp
@@ -10,14 +10,14 @@
  * @param start
  * @param size
  */
-CorrPowerFilter::WorkBlock::WorkBlock(int index, qint64 start, qint64 size):
+CorrPowerFilter::WorkBlock::WorkBlock(int index, qint64 start, qint64 size, Pairwise::Index startIndex) :
     EAbstractAnalyticBlock(index),
     _start(start),
-    _size(size)
+    _size(size),
+    _startIndex(startIndex)
 {
-    EDEBUG_FUNC(this,index,start,size);
+    EDEBUG_FUNC(this,index,startpair,size);
 }
-
 
 
 /*!

--- a/src/core/corrpower_workblock.cpp
+++ b/src/core/corrpower_workblock.cpp
@@ -28,8 +28,7 @@ CorrPowerFilter::WorkBlock::WorkBlock(int index, qint64 start, qint64 size, Pair
 void CorrPowerFilter::WorkBlock::write(QDataStream& stream) const
 {
     EDEBUG_FUNC(this,&stream);
-
-    stream << _start << _size;
+    stream << _start << _size << _startIndex.getX() << _startIndex.getY();
 }
 
 
@@ -42,6 +41,7 @@ void CorrPowerFilter::WorkBlock::write(QDataStream& stream) const
 void CorrPowerFilter::WorkBlock::read(QDataStream& stream)
 {
     EDEBUG_FUNC(this,&stream);
-
-    stream >> _start >> _size;
+    qint32 x,y;
+    stream >> _start >> _size >> x >> y;
+    _startIndex = Pairwise::Index(x,y);
 }

--- a/src/core/corrpower_workblock.h
+++ b/src/core/corrpower_workblock.h
@@ -15,21 +15,28 @@ public:
      * Construct a new work block in an uninitialized null state.
      */
     explicit WorkBlock() = default;
-    explicit WorkBlock(int index, qint64 start, qint64 size);
-    qint64 start() const { return _start; }
+    explicit WorkBlock(int index, qint64 start, qint64 size, Pairwise::Index startIndex);
+
+    Pairwise::Index startIndex() const { return _startIndex; }
     qint64 size() const { return _size; }
+    qint64 start() const {return _start;}
+
 protected:
     virtual void write(QDataStream& stream) const override final;
     virtual void read(QDataStream& stream) override final;
 private:
     /*!
-     * The pairwise index of the first pair to process.
+     * The the number of the starting pair.
      */
     qint64 _start;
     /*!
      * The number of pairs to process.
      */
     qint64 _size;
+    /*!
+     * The starting index.
+     */
+    Pairwise::Index _startIndex;
 };
 
 

--- a/src/core/pairwise_matrix_pair.h
+++ b/src/core/pairwise_matrix_pair.h
@@ -32,11 +32,13 @@ namespace Pairwise
         virtual int clusterSize() const = 0;
         virtual bool isEmpty() const = 0;
         void write(const Index& index);
+        void seek(qint64 count, Index& start) const;
         void read(const Index& index) const;
         void reset() const { _rawIndex = 0; }
         void readNext() const;
         bool hasNext() const { return _rawIndex != _cMatrix->_clusterSize; }
-        const Index& index() const { return _index; }
+        const Index& index() const { return _index; }        
+        qint64 rawindex() const { return _rawIndex; }
         Pair& operator=(const Pair&) = default;
         Pair& operator=(Pair&&) = default;
     protected:


### PR DESCRIPTION
This is a fix for the corrpower analytic.  As described in issue #126, this analytic would take an extreme amount of time to complete.   The problem was that it was not using a correct index for each working block and would repeatedly process the same elements.  To fix this, I added a `seek` function to the `pairwise_matrix_pair.cpp` file that is used to properly find the index for each block.  
