### PR TITLE
138 cond test mpirun

### DIFF
--- a/src/core/conditionaltest.cpp
+++ b/src/core/conditionaltest.cpp
@@ -113,26 +113,25 @@ void ConditionalTest::process(const EAbstractAnalyticBlock* result)
 
     for ( auto& pair : resultBlock->pairs() )
     {
-        // copy the values form the pairs to the CSM
-        if ( pair.pValues.size() > 0 )
+        // Create pair objects for the output data file.
+        CSMatrix::Pair csmPair(_out);
+
+        // Iterate through the clusters in the pair.
+        for ( int k = 0; k < pair.pValues.size(); ++k )
         {
-            // Create pair objects for the output data file.
-            CSMatrix::Pair csmPair(_out);
+            // add each cluster into the CSM
+            csmPair.addCluster(1, _numTests);
 
-            // Iterate through the clusters in the pair.
-            for ( int k = 0; k < pair.pValues.size(); ++k )
+            for ( int i = 0; i < pair.pValues.at(k).size(); ++i )
             {
-                // add each cluster into the CSM
-                csmPair.addCluster(1, _numTests);
-
-                for ( int i = 0; i < pair.pValues.at(k).size(); ++i )
-                {
-                    csmPair.at(k, i, "pvalue") = pair.pValues.at(k).at(i);
-                    csmPair.at(k, i, "r2") = pair.r2.at(k).at(i);
-                }
+                csmPair.at(k, i, "pvalue") = pair.pValues.at(k).at(i);
+                csmPair.at(k, i, "r2") = pair.r2.at(k).at(i);
             }
+        }
 
-            // write the info into the CSM
+        // write the info into the CSM
+        if ( csmPair.clusterSize() > 0 )
+        {
             csmPair.write(pair.index);
         }
     }
@@ -367,6 +366,8 @@ void ConditionalTest::setData()
     }
 }
 
+
+
 void ConditionalTest::setFeatures()
 {
     EDEBUG_FUNC(this);
@@ -415,6 +416,8 @@ void ConditionalTest::setNumTests()
         }
     }
 }
+
+
 
 /*!
  * An interface to decide what the test types are going to be for each feature.
@@ -666,6 +669,7 @@ QString ConditionalTest::testNames()
 
     return string;
 }
+
 
 
 /*!

--- a/src/core/conditionaltest.cpp
+++ b/src/core/conditionaltest.cpp
@@ -178,46 +178,51 @@ void ConditionalTest::initialize()
 
     // only the master process needs to validate arguments
     auto& mpi {Ace::QMPI::instance()};
-
-    if ( !mpi.isMaster() )
+    if ( mpi.isMaster() )
     {
-        return;
+
+        // make sure input data is valid
+        if ( !_ccm )
+        {
+            E_MAKE_EXCEPTION(e);
+            e.setTitle(tr("Invalid Argument"));
+            e.setDetails(tr("Did not get valid CCM data argument."));
+            throw e;
+        }
+
+        if ( !_cmx )
+        {
+            E_MAKE_EXCEPTION(e);
+            e.setTitle(tr("Invalid Argument"));
+            e.setDetails(tr("Did not get valid CMX data argument."));
+            throw e;
+        }
+
+        if ( !_amx )
+        {
+            E_MAKE_EXCEPTION(e);
+            e.setTitle(tr("Invalid Argument"));
+            e.setDetails(tr("Did not get valid AMX data argument."));
+            throw e;
+        }
+
+        if (  !_emx )
+        {
+            E_MAKE_EXCEPTION(e);
+            e.setTitle(tr("Invalid Argument"));
+            e.setDetails(tr("Did not get valid EMX data argument."));
+            throw e;
+        }
+
+        // Initialize work block size.
+        if ( _workBlockSize == 0 )
+        {
+            int numWorkers = std::max(1, mpi.size() - 1);
+            _workBlockSize = std::min(32768LL, _cmx->size() / numWorkers);
+        }
     }
 
-    // make sure input data is valid
-    if ( !_ccm )
-    {
-        E_MAKE_EXCEPTION(e);
-        e.setTitle(tr("Invalid Argument"));
-        e.setDetails(tr("Did not get valid CCM data argument."));
-        throw e;
-    }
-
-    if ( !_cmx )
-    {
-        E_MAKE_EXCEPTION(e);
-        e.setTitle(tr("Invalid Argument"));
-        e.setDetails(tr("Did not get valid CMX data argument."));
-        throw e;
-    }
-
-    if ( !_amx )
-    {
-        E_MAKE_EXCEPTION(e);
-        e.setTitle(tr("Invalid Argument"));
-        e.setDetails(tr("Did not get valid AMX data argument."));
-        throw e;
-    }
-
-    if (  !_emx )
-    {
-        E_MAKE_EXCEPTION(e);
-        e.setTitle(tr("Invalid Argument"));
-        e.setDetails(tr("Did not get valid EMX data argument."));
-        throw e;
-    }
-
-    // open the stream to the coprrect file.
+    // open the stream to the correct file.
     _stream.setDevice(_amx);
 
     // atain number of lines in the file.
@@ -256,14 +261,6 @@ void ConditionalTest::initialize()
     // Order the data read in from the AMX file by the
     // sample order in the EMX file.
     orderLabelsBySample();
-
-    // Initialize work block size.
-    if ( _workBlockSize == 0 )
-    {
-        int numWorkers = std::max(1, mpi.size() - 1);
-
-        _workBlockSize = std::min(32768LL, _cmx->size() / numWorkers);
-    }
 }
 
 

--- a/src/core/conditionaltest.cpp
+++ b/src/core/conditionaltest.cpp
@@ -239,24 +239,31 @@ void ConditionalTest::initialize()
         throw e;
     }
 
-    // read in the annotation matrix, as it holds the details on what we need to do for our tests
-    Test();
-    override();
-    readInAMX(_features, _data, _testType);
+    // Parse the user specified tests and test types. The test types provided by
+    // the user will override the defaults.
+    setUserTests();
+    setUserTestTypes();
 
-    rearrangeSamples();
+    // Read in the annotation matrix.
+    // Set the stream to the right file.
+    _stream.setDevice(_amx);
+    _stream.seek(0);
+    setFeatures();
+    setTestTypes();
+    setData();
+    setNumTests();
 
-    // initialize work block size
+    // Order the data read in from the AMX file by the
+    // sample order in the EMX file.
+    orderLabelsBySample();
+
+    // Initialize work block size.
     if ( _workBlockSize == 0 )
     {
         int numWorkers = std::max(1, mpi.size() - 1);
 
         _workBlockSize = std::min(32768LL, _cmx->size() / numWorkers);
     }
-
-    // CSM specific
-    qint32 maxCluster = 64, subHeadersize = 12;
-    initialize(maxCluster,subHeadersize,_features,_testType,_data);
 }
 
 
@@ -274,95 +281,72 @@ void ConditionalTest::initializeOutputs()
         e.setTitle(tr("Invalid Argument"));
         e.setDetails(tr("The required output data object was not set."));
         throw e;
+    }    
+
+    // Needed by the CSM specific initializer
+    EMetaArray features;
+    QVector<EMetaArray> featureInfo;
+    QVector<EMetaArray> Data;
+    Data.resize(_data.size());
+    featureInfo.resize(_features.size());
+
+    // Meta Data for Features.
+    for ( int i = 0; i < _features.size(); i++ )
+    {
+        features.append(_features.at(i).at(0));
     }
 
-    _out->setTestCount(_numTests);
+    // Meta Data for the test types of the catagories.
+    for ( int i = 0; i < featureInfo.size(); i++ )
+    {
+        switch(_testType.at(i))
+        {
+            case CATEGORICAL : featureInfo[i].append(tr("Categorical"));
+                break;
+            case ORDINAL : featureInfo[i].append(tr("Ordinal"));
+                break;
+            case QUANTITATIVE : featureInfo[i].append(tr("Quantitative"));
+                break;
+            case NONE : featureInfo[i].append(tr("None"));
+                break;
+            default : featureInfo[i].append(tr("Unknown"));
+                break;
+        }
+    }
+
+    // Meta Data for the sub categories.
+    for ( int i = 0; i < _features.size(); i++ )
+    {
+        for ( int j = 0; j < _features.at(i).size(); j++ )
+        {
+            featureInfo[i].append(_features.at(i).at(j));
+        }
+    }
+
+    // Meta Data for all the data in the annotation matrix.
+    for ( int i = 0; i < _data.size(); i++ )
+    {
+        for ( int j = 0; j < _data.at(i).size(); j++ )
+        {
+            Data[i].append(_data.at(i).at(j).toString());
+        }
+    }
+
+    // inserts the Meta Data into the CSM Object stored on the disk.
+    qint32 maxCluster = 64, subHeaders = 12;
+    _out->initialize(features, featureInfo, Data, _numTests, testNames(),
+                     _emx->geneNames(), maxCluster, subHeaders);
 }
 
 
 
-/*!
- * An interface to read in the contents of an annotation matrix and produces
- * useful information from it.
- *
- * @param amxdata An initially empty array, stores the features and labels of
- *       the annotation matrix.
- *
- * @param data An initially empty array, stores all of the data corrosponding
- *       to the features in the annotation matrix.
- *
- * @param dataTestType The type of test we will run on the data under a
- *       particular feature.
- */
-void ConditionalTest::readInAMX(
-    QVector<QVector<QString>>& amxdata,
-    QVector<QVector<QVariant>>& data,
-    QVector<TestType>& dataTestType)
+void ConditionalTest::setData()
 {
-    EDEBUG_FUNC(this,&amxdata,&data,&dataTestType);
+    EDEBUG_FUNC(this);
 
-    // set the stream to the right file
-    _stream.setDevice(_amx);
-    _stream.seek(0);
+    QString line;
 
-    // read a line form the input file
-    QString line = _stream.readLine();
-
-    // the file can be a csv or a tab delimited AMX
-    // default is tab diliniated
-    if ( _delimiter == "tab" )
-    {
-        _delimiter = "\t";
-    }
-
-    // splits the file along the commas or tabs depending on what it has inside
-    auto words = line.split(_delimiter, QString::SkipEmptyParts, Qt::CaseInsensitive);
-
-    // If a field never changes, we don't have to store copies of that data.
-    QVector<int> changed;
-
-    // put the column names into the amxdata array, that will be later put into the meta data
-    for ( int i = 0; i < words.size(); i++ )
-    {
-        amxdata.append(QVector<QString>());
-        amxdata[i].append(words[i]);
-        dataTestType.append(UNKNOWN);
-        data.append(QVector<QVariant>());
-        changed.append(1);
-    }
-
-    configureTests(dataTestType);
-
-    // we need to change the test types here if the user has overridden them
-    for ( int i = 0; i < _override.size(); i++ )
-    {
-        for ( int j = 0; j < dataTestType.size(); j++ )
-        {
-            if ( amxdata.at(j).at(0) == _override.at(i).at(0) )
-            {
-                if ( QString::compare(_override.at(i).at(1), "CATEGORICAL", Qt::CaseInsensitive) == 0 )
-                {
-                    dataTestType[j] = CATEGORICAL;
-                }
-                else if ( QString::compare(_override.at(i).at(1), "ORDINAL", Qt::CaseInsensitive) == 0 )
-                {
-                    dataTestType[j] = ORDINAL;
-                }
-                else if ( QString::compare(_override.at(i).at(1), "QUANTITATIVE", Qt::CaseInsensitive) == 0 )
-                {
-                    dataTestType[j] = QUANTITATIVE;
-                }
-                else {
-                    E_MAKE_EXCEPTION(e);
-                    e.setTitle(tr("Unknown override type in the --feat_type argument."));
-                    e.setDetails(tr("Unknown override type: %1.  Valid choices are: %2")
-                        .arg(_override.at(i).at(1))
-                        .arg("categorical, quantitative, ordinal"));
-                    throw e;
-                }
-            }
-        }
-    }
+    _data.resize(_features.size());
 
     for ( int i = 1; i < _amxNumLines; i++ )
     {
@@ -373,59 +357,88 @@ void ConditionalTest::readInAMX(
         // add the data to our arrays
         for ( int j = 0; j < words2.size(); j++ )
         {
-            data[j].append(words2[j]);
-            if ( dataTestType.at(j) == CATEGORICAL )
+            _data[j].append(words2[j]);
+            if ( _testType.at(j) == CATEGORICAL )
             {
                 // this will add treatments types, leaf types, and any other types into the meta data
-                if ( !amxdata.at(j).contains(words2[j]) )
+                if ( !_features.at(j).contains(words2[j]) )
                 {
-                    amxdata[j].append(words2[j]);
-                    changed[j] = 0;
+                    _features[j].append(words2[j]);
                 }
             }
         }
     }
+}
 
-    // Add in labels the user has chosen to test.
-    for ( int j = 0; j < amxdata.size(); j++ )
+void ConditionalTest::setFeatures()
+{
+    EDEBUG_FUNC(this);
+
+    // Read the header line from the input file.
+    QString line = _stream.readLine();
+
+    // The file can be a csv or a tab delimited AMX. The default is tab delimited.
+    if ( _delimiter == "tab" )
     {
-        int check = 0;
-        for ( int k = 0; k < _Test.size(); k++ )
-        {
-            if ( amxdata.at(j).at(0) == _Test.at(k) )
-            {
-                check = 1;
-            }
-        }
-        if ( check == 0 )
-        {
-            dataTestType[j] = NONE;
-        }
+        _delimiter = "\t";
+    }
+
+    // Splits the line using the delimiter.
+    auto headers = line.split(_delimiter, QString::SkipEmptyParts, Qt::CaseInsensitive);
+
+
+    // Put the column names from the header into the amxdata array.
+    for ( int i = 0; i < headers.size(); i++ )
+    {
+        _features.append(QVector<QString>());
+        _features[i].append(headers[i]);
     }
 }
 
 
+
+void ConditionalTest::setNumTests()
+{
+    EDEBUG_FUNC(this);
+    _numTests = 0;
+    // Set the feature information in the meta data
+    for ( int i = 0; i < _features.size(); i++ )
+    {
+        if ( _testType[i] == CATEGORICAL )
+        {
+            _numTests += _features[i].size() - 1;
+        }
+        // Ordinal and Quantitative
+        else
+        {
+            if ( _testType[i] != NONE && _testType[i] != UNKNOWN )
+            {
+                ++_numTests;
+            }
+        }
+    }
+}
 
 /*!
  * An interface to decide what the test types are going to be for each feature.
  *
  * @param dataTestType An array storing the test information for each feature.
  */
-void ConditionalTest::configureTests(QVector<TestType>& dataTestType)
+void ConditionalTest::setTestTypes()
 {
-    EDEBUG_FUNC(this,&dataTestType);
-
-    // Counts here for an aproximation for what test type it should be.
-    QVector<QVector<qint32>> counts;
-    counts.resize(dataTestType.size());
-
-    for ( int i = 0 ; i < counts.size(); i++ )
-    {
-        counts[i].resize(4);
-    }
+    EDEBUG_FUNC(this);
 
     QString line;
     int num_lines = 0;
+
+    // Counts here for an aproximation for what test type it should be.
+    QVector<QVector<qint32>> counts(_features.size());
+
+    _testType.resize(_features.size());
+    for (int i = 0; i < _features.size(); i++) {
+        _testType[i] = UNKNOWN;
+        counts[i].resize(4);
+    }
 
     while(!_stream.atEnd())
     {
@@ -474,26 +487,76 @@ void ConditionalTest::configureTests(QVector<TestType>& dataTestType)
         // column ordinal.
         if ( counts.at(i).at(ORDINAL) + counts[i][UNKNOWN] == num_lines )
         {
-            dataTestType[i] = ORDINAL;
+            _testType[i] = ORDINAL;
         }
         // If all of the values are quantitative or ordinal (integer) or missing
         // then we'll consider this column quantitative.
         else if ( counts.at(i).at(QUANTITATIVE) + counts.at(i).at(ORDINAL) + counts[i][UNKNOWN] == num_lines )
         {
-            dataTestType[i] = QUANTITATIVE;
+            _testType[i] = QUANTITATIVE;
         }
         // If all of the values are strings then it's categorical
         else if ( counts.at(i).at(CATEGORICAL) + counts[i][UNKNOWN]== num_lines )
         {
-            dataTestType[i] = CATEGORICAL;
+            _testType[i] = CATEGORICAL;
         }
         // If we're here then it means we have some combination of strings and
         // numbers. This column cannot be considered.
         else {
-            dataTestType[i] = NONE;
+            _testType[i] = NONE;
         }
     }
 
+    // We need to change the test types here if the user has overridden them.
+    for ( int i = 0; i < _userTestTypes.size(); i++ )
+    {
+        for ( int j = 0; j < _testType.size(); j++ )
+        {
+            if ( _features.at(j).at(0) == _userTestTypes.at(i).at(0) )
+            {
+                if ( QString::compare(_userTestTypes.at(i).at(1), "CATEGORICAL", Qt::CaseInsensitive) == 0 )
+                {
+                    _testType[j] = CATEGORICAL;
+                }
+                else if ( QString::compare(_userTestTypes.at(i).at(1), "ORDINAL", Qt::CaseInsensitive) == 0 )
+                {
+                    _testType[j] = ORDINAL;
+                }
+                else if ( QString::compare(_userTestTypes.at(i).at(1), "QUANTITATIVE", Qt::CaseInsensitive) == 0 )
+                {
+                    _testType[j] = QUANTITATIVE;
+                }
+                else {
+                    E_MAKE_EXCEPTION(e);
+                    e.setTitle(tr("Unknown override type in the --feat_type argument."));
+                    e.setDetails(tr("Unknown override type: %1.  Valid choices are: %2")
+                        .arg(_userTestTypes.at(i).at(1))
+                        .arg("categorical, quantitative, ordinal"));
+                    throw e;
+                }
+            }
+        }
+    }
+
+    // If the user has specified tests that need to be
+    // run then set all others to NONE.
+    for ( int j = 0; j < _features.size(); j++ )
+    {
+        int check = 0;
+        for ( int k = 0; k < _userTests.size(); k++ )
+        {
+            if ( _features.at(j).at(0) == _userTests.at(k) )
+            {
+                check = 1;
+            }
+        }
+        if ( check == 0 )
+        {
+            _testType[j] = NONE;
+        }
+    }
+
+    // Reset the file back to the beginning for reparsing.
     _stream.seek(0);
     _stream.readLine();
 }
@@ -535,14 +598,14 @@ int ConditionalTest::max(QVector<qint32> &counts) const
 /*!
  * An interface to sperate the test out.
  */
-void ConditionalTest::Test()
+void ConditionalTest::setUserTests()
 {
     EDEBUG_FUNC(this);
 
     // make sure input data is valid
-    _Test = _Testing.split(",", QString::SkipEmptyParts, Qt::CaseInsensitive).toVector();
+    _userTests = _userTestsStr.split(",", QString::SkipEmptyParts, Qt::CaseInsensitive).toVector();
 
-    if ( _Test.isEmpty() )
+    if ( _userTests.isEmpty() )
     {
         E_MAKE_EXCEPTION(e);
         e.setTitle(tr("Invalid Argument"));
@@ -556,21 +619,21 @@ void ConditionalTest::Test()
 /*!
  * An interface to override testing types.
  */
-void ConditionalTest::override()
+void ConditionalTest::setUserTestTypes()
 {
     EDEBUG_FUNC(this);
 
-    auto words = _testOverride.split(",", QString::SkipEmptyParts, Qt::CaseInsensitive).toVector();
+    auto words = _userTestTypesStr.split(",", QString::SkipEmptyParts, Qt::CaseInsensitive).toVector();
 
     for ( int i = 0; i < words.size(); i++ )
     {
-        _override.append(QVector<QString>());
+        _userTestTypes.append(QVector<QString>());
 
         auto word = words.at(i).split(":");
 
         for ( auto item : word )
         {
-            _override[i].append(item);
+            _userTestTypes[i].append(item);
         }
     }
 }
@@ -608,91 +671,11 @@ QString ConditionalTest::testNames()
 }
 
 
-
-/*!
- * An interface to initialize the metadata corrosponding to the data retrived
- * from the annotation matrix.
- *
- * @param maxClusterSize The maximum number of clusters that can be stored in
- *       a pair.
- *
- * @param subHeaderSize The size of the subheader of the matrix, in this case
- *       it only stores sample size.
- *
- * @param amxData Stores feature names from the annotation array.
- *
- * @param testtype The type of test that was ran on the features.
- *
- * @param genenames Names of all the genes from the gene expression matrix.
- *
- * @param data All of the data corrosponding to the features from the annotation
- *       array.
- */
-void ConditionalTest::initialize(qint32 &maxClusterSize, qint32 &subHeaderSize,QVector<QVector<QString>> &amxData, QVector<TestType> &testType, QVector<QVector<QVariant>> &data)
-{
-    EDEBUG_FUNC(this,&maxClusterSize,&subHeaderSize,&amxData,&testType,&data);
-
-    // needed by the CSM specific initializer
-    EMetaArray Features;
-    QVector<EMetaArray> featureInfo;
-    QVector<EMetaArray> Data;
-    Data.resize(data.size());
-    featureInfo.resize(amxData.size());
-
-    // Meta Data for Features.
-    for ( int i = 0; i < amxData.size(); i++ )
-    {
-        Features.append(amxData.at(i).at(0));
-    }
-
-    // Meta Data for the test types of the catagories.
-    for ( int i = 0; i < featureInfo.size(); i++ )
-    {
-        switch(testType.at(i))
-        {
-        case CATEGORICAL : featureInfo[i].append(tr("Categorical"));
-            break;
-        case ORDINAL : featureInfo[i].append(tr("Ordinal"));
-            break;
-        case QUANTITATIVE : featureInfo[i].append(tr("Quantitative"));
-            break;
-        case NONE : featureInfo[i].append(tr("None"));
-            break;
-        default : featureInfo[i].append(tr("Unknown"));
-            break;
-        }
-    }
-
-    // Meta Data for the sub catagories.
-    for ( int i = 0; i < amxData.size(); i++ )
-    {
-        for ( int j = 0; j < amxData.at(i).size(); j++ )
-        {
-            featureInfo[i].append(amxData.at(i).at(j));
-        }
-    }
-
-    // Meta Data for all the data in the annotation matrix.
-    for ( int i = 0; i < data.size(); i++ )
-    {
-        for ( int j = 0; j < data.at(i).size(); j++ )
-        {
-            Data[i].append(data.at(i).at(j).toString());
-        }
-    }
-
-    // inserts the Meta Data into the CSM Object stored on the disk.
-    _out->initialize(Features, featureInfo, Data, _numTests, testNames());
-    _out->initialize(_emx->geneNames(), maxClusterSize, subHeaderSize);
-}
-
-
-
 /*!
  * An interface to move the amx data around so that the emx samples and the
  * annotation matrix samples are in the same order
  */
-void ConditionalTest::rearrangeSamples()
+void ConditionalTest::orderLabelsBySample()
 {
     int sampleIndex = 0;
     int startIndex = 0;

--- a/src/core/conditionaltest.h
+++ b/src/core/conditionaltest.h
@@ -54,29 +54,33 @@ public:
     virtual void initializeOutputs() override final;
 
 public:
-    /*!
-     * Reads in the annotation matrix populating the metadata when its done.
-     */
-    void readInAMX(QVector<QVector<QString>>& amxdata,
-                   QVector<QVector<QVariant>>& data,
-                   QVector<TestType>& dataTestType);
-    void configureTests(QVector<TestType>& dataTestType);
     int max(QVector<qint32> &counts) const;
-    /*!
-     * Test overrides.
-     */
-    void Test();
-    void override();
     /*!
      * Crates a string of test names, delimited by a colon.
      */
     QString testNames();
 
-    void initialize(qint32 &maxClusterSize, qint32 &subHeaderSize, QVector<QVector<QString>> &amxData, QVector<TestType> &testType, QVector<QVector<QVariant>> &data);
+    void initialize(qint32 &maxClusterSize, qint32 &subHeaderSize);
 
-    void rearrangeSamples();
 
 private:
+
+    /*!
+     * Test overrides.
+     */
+    void setUserTests();
+    void setUserTestTypes();
+
+    /*!
+     * Reads in the annotation matrix populating the metadata when its done.
+     */
+    void setFeatures();
+    void setTestTypes();
+    void setTestCount();
+    void setData();
+    void orderLabelsBySample();
+    void setNumTests();
+
     /*!
      * Pointer to the input expression matrix.
      */
@@ -100,13 +104,13 @@ private:
     /*!
      * User provided features not to test.
      */
-    QString _Testing{""};
-    QVector<QString> _Test;
+    QString _userTestsStr{""};
+    QVector<QString> _userTests;
     /*!
      * User provided test type overrides.
      */
-    QString _testOverride{""};
-    QVector<QVector<QString>> _override;
+    QString _userTestTypesStr{""};
+    QVector<QVector<QString>> _userTestTypes;
     /*!
      * Assosiated stream for the annotation matrix input file.
      */

--- a/src/core/conditionaltest.h
+++ b/src/core/conditionaltest.h
@@ -60,9 +60,6 @@ public:
      */
     QString testNames();
 
-    void initialize(qint32 &maxClusterSize, qint32 &subHeaderSize);
-
-
 private:
 
     /*!

--- a/src/core/conditionaltest_input.cpp
+++ b/src/core/conditionaltest_input.cpp
@@ -179,10 +179,10 @@ void ConditionalTest::Input::set(int index, const QVariant& value)
         _base->_missing = value.toString();
         break;
     case TEST:
-        _base->_Testing = value.toString();
+        _base->_userTestsStr = value.toString();
         break;
     case OVERRIDES:
-        _base->_testOverride = value.toString();
+        _base->_userTestTypesStr = value.toString();
         break;
     }
 }

--- a/src/core/conditionaltest_serial.cpp
+++ b/src/core/conditionaltest_serial.cpp
@@ -66,15 +66,7 @@ std::unique_ptr<EAbstractAnalyticBlock> ConditionalTest::Serial::execute(const E
         QVector<QVector<double>> r2(ccmPair.clusterSize());
 
         // for each cluster in the pair, run the binomial or linear regression tests
-        int cluster_size = ccmPair.clusterSize();
-        if ( cluster_size == 0 )
-        {
-           ccmPair.readNext();
-           cmxPair.readNext();
-           continue;
-        }
-
-        for ( qint32 clusterIndex = 0; clusterIndex < cluster_size; clusterIndex++ )
+        for ( qint32 clusterIndex = 0; clusterIndex < ccmPair.clusterSize(); clusterIndex++ )
         {
 
             // resize for room for each test.
@@ -136,6 +128,7 @@ std::unique_ptr<EAbstractAnalyticBlock> ConditionalTest::Serial::execute(const E
 }
 
 
+
 /*!
  * Check to see if a matrix is empty.
  *
@@ -160,12 +153,19 @@ bool ConditionalTest::Serial::isEmpty(QVector<QVector<double>>& matrix)
     return true;
 }
 
+
+
 /*!
  * Run the first hypergeometric
  *
  */
-void ConditionalTest::Serial::hypergeom(QVector<QString> amx_column, CCMatrix::Pair& ccmPair, int clusterIndex,
-                                        int featureIndex, int labelIndex, double &result)
+void ConditionalTest::Serial::hypergeom(
+    const QVector<QString>& amx_column,
+    const CCMatrix::Pair& ccmPair,
+    int clusterIndex,
+    int featureIndex,
+    int labelIndex,
+    double &result)
 {
     EDEBUG_FUNC(this);
 
@@ -312,7 +312,12 @@ void ConditionalTest::Serial::hypergeom(QVector<QString> amx_column, CCMatrix::P
 /*!
  * Performs the regression test for quantitative data.
  */
-void ConditionalTest::Serial::regression(QVector<QString> amx_column, CCMatrix::Pair& ccmPair, int clusterIndex, int featureIndex, QVector<double>& results)
+void ConditionalTest::Serial::regression(
+    const QVector<QString>& amx_column,
+    const CCMatrix::Pair& ccmPair,
+    int clusterIndex,
+    int featureIndex,
+    QVector<double>& results)
 {
     EDEBUG_FUNC(this, &amxInfo, &ccmPair, clusterIndex);
 

--- a/src/core/conditionaltest_serial.cpp
+++ b/src/core/conditionaltest_serial.cpp
@@ -207,8 +207,6 @@ void ConditionalTest::Serial::hypergeom(CCMatrix::Pair& ccmPair, int clusterInde
     int k = labels_in_cluster;
     // t total elements were selected.
     int t = cluster_size;
-    // Holds the pvalue
-    double pvalue = 1;
 
     // If our dataset is large, the power to detect the effect
     // size increases, resulting in potentially insignificant
@@ -419,7 +417,7 @@ void ConditionalTest::Serial::regression(CCMatrix::Pair& ccmPair, int clusterInd
 
     // Calculate R^2 and R^2-adjusted
     double R2 = 1 - (SSE / SST);
-    double R2adj = 1.0 - ((double) test_cluster_size - 1) / DFE * (1 - R2);
+    //double R2adj = 1.0 - ((double) test_cluster_size - 1) / DFE * (1 - R2);
 
     // Calculate the p-value. We will do this using the F-test.
     double Fstat = MSM/MSE;

--- a/src/core/conditionaltest_serial.cpp
+++ b/src/core/conditionaltest_serial.cpp
@@ -18,7 +18,9 @@
 /*!
  * Create a serial object.
  */
-ConditionalTest::Serial::Serial(ConditionalTest* parent) : EAbstractAnalyticSerial(parent), _base(parent)
+ConditionalTest::Serial::Serial(ConditionalTest* parent) :
+    EAbstractAnalyticSerial(parent),
+    _base(parent)
 {
     EDEBUG_FUNC(this,parent);
 }
@@ -63,31 +65,44 @@ std::unique_ptr<EAbstractAnalyticBlock> ConditionalTest::Serial::execute(const E
         QVector<QVector<double>> pValues(ccmPair.clusterSize());
         QVector<QVector<double>> r2(ccmPair.clusterSize());
 
-        // for each cluster in the pair, run the binomial and linear regression tests
-        for ( qint32 clusterIndex = 0; clusterIndex < ccmPair.clusterSize(); clusterIndex++ )
+        // for each cluster in the pair, run the binomial or linear regression tests
+        int cluster_size = ccmPair.clusterSize();
+        if ( cluster_size == 0 )
+        {
+           continue;
+        }
+        for ( qint32 clusterIndex = 0; clusterIndex < cluster_size; clusterIndex++ )
         {
             // resize for room for each test.
             pValues[clusterIndex].resize(_base->_numTests);
             r2[clusterIndex].resize(_base->_numTests);
 
-            for ( qint32 featureIndex = 0, testIndex = 0; featureIndex < _base->_features.size(); featureIndex++ )
-            {
-                if ( _base->_testType.at(featureIndex) == NONE || _base->_testType.at(featureIndex) == UNKNOWN )
-                {
-                    continue;
-                }
 
-                if ( _base->_testType.at(featureIndex) == QUANTITATIVE || _base->_testType.at(featureIndex) == ORDINAL )
+            // Iterate through all of the tests.
+            int test_index = 0;
+            for ( qint32 featureIndex = 0; featureIndex < _base->_features.size(); featureIndex++ )
+            {
+                if ( _base->_testType.at(featureIndex) == QUANTITATIVE ||
+                     _base->_testType.at(featureIndex) == ORDINAL )
                 {
-                    prepAnxData(_base->_features.at(featureIndex).at(0), featureIndex, _base->_testType.at(featureIndex));
-                    test(ccmPair, clusterIndex, testIndex, featureIndex, 0, pValues, r2);
+                    // For linear regresssion we need a variable that will hold the
+                    // pvalue and the r2 value.
+                    QVector<double> results(2);
+                    regression(ccmPair, clusterIndex, featureIndex, results);
+                    pValues[clusterIndex][test_index] = results.at(0);
+                    r2[clusterIndex][test_index] = results.at(1);
+                    test_index++;
                 }
                 else if ( _base->_testType.at(featureIndex) == CATEGORICAL )
                 {
+                    // Loop through each label (category) of the feature.
                     for ( qint32 labelIndex = 1; labelIndex < _base->_features.at(featureIndex).size(); labelIndex++ )
                     {
-                        prepAnxData(_base->_features.at(featureIndex).at(labelIndex), featureIndex, _base->_testType.at(featureIndex));
-                        test(ccmPair, clusterIndex, testIndex, featureIndex, labelIndex, pValues, r2);
+                        double results;
+                        hypergeom(ccmPair, clusterIndex, featureIndex, labelIndex, results);
+                        pValues[clusterIndex][test_index] = results;
+                        r2[clusterIndex][test_index] = qQNaN();
+                        test_index++;
                     }
                 }
             }
@@ -107,41 +122,6 @@ std::unique_ptr<EAbstractAnalyticBlock> ConditionalTest::Serial::execute(const E
 
     return std::unique_ptr<EAbstractAnalyticBlock>(resultBlock);
 }
-
-
-
-/*!
- * Prepare the annotation matrix data for testing.
- *
- * @param testLabel The label you are testing on.
- *
- * @param dataIndex The feature the label is part of.
- *
- * @return The number of samples in total of the test label.
- */
-int ConditionalTest::Serial::prepAnxData(QString testLabel, int dataIndex, TestType testType)
-{
-    EDEBUG_FUNC(this, testLabel, dataIndex);
-
-    // get the needed data fro the comparison
-    _catCount = 0;
-    _amxData.resize(_base->_data.at(dataIndex).size());
-
-    // populate array with annotation data
-    for ( int j = 0; j < _base->_data.at(dataIndex).size(); j++ )
-    {
-        _amxData[j] = _base->_data.at(dataIndex).at(j).toString();
-
-        // if data is the same as the test label add one to the catagory counter
-        if ( testType == _base->CATEGORICAL && _amxData[j] == testLabel )
-        {
-            _catCount++;
-        }
-    }
-
-    return _catCount;
-}
-
 
 
 /*!
@@ -168,120 +148,46 @@ bool ConditionalTest::Serial::isEmpty(QVector<QVector<double>>& matrix)
     return true;
 }
 
-
-
 /*!
- * Prepare the cluster category count information.
+ * Run the first hypergeometric
  *
- * @param ccmPair The gene pair that we are counting the labels for.
- *
- * @param clusterIndex The number cluster we are in in the pair
- *
- * @return The number of labels in the given cluster.
  */
-int ConditionalTest::Serial::clusterInfo(CCMatrix::Pair& ccmPair, int clusterIndex, QString label, TestType testType)
+void ConditionalTest::Serial::hypergeom(CCMatrix::Pair& ccmPair, int clusterIndex,
+                                        int featureIndex, int labelIndex, double &result)
 {
-    _catCount = _clusterSize = _catInCluster = 0;
+    EDEBUG_FUNC(this);
 
-    // Look through all the samples in the mask.
-    for ( qint32 i = 0; i < _base->_emx->sampleSize(); i++ )
+    // Get the test name and the test type.
+    QString test_label = _base->_features.at(featureIndex).at(labelIndex);
+    TestType test_type = _base->_testType.at(featureIndex);
+
+    // We need to get the data for the feature being tested and
+    // count how many entries there are for the label in the
+    // annotation data.
+    int num_samples = _base->_data.at(featureIndex).size();
+    int cluster_size = 0;
+    int label_count = 0;
+    int labels_in_cluster = 0;
+    QVector<QString> amx_column(num_samples);
+    for ( int j = 0; j < num_samples; j++ )
     {
-        // If the sample label matches with the given label.
-        if ( testType == _base->CATEGORICAL && _amxData.at(i) == label )
+        amx_column[j] = _base->_data.at(featureIndex).at(j).toString();
+
+        // if data is the same as the test label add one to the catagory counter
+        if ( test_type == _base->CATEGORICAL && amx_column[j] == test_label )
         {
-            _catCount++;
+            label_count++;
         }
-
-        if ( ccmPair.at(clusterIndex, i) == 1 )
+        if ( ccmPair.at(clusterIndex, j) == 1 )
         {
-            _clusterSize++;
-
-            if ( testType == _base->CATEGORICAL && _amxData.at(i) == label )
+            cluster_size++;
+            if ( test_type == _base->CATEGORICAL && amx_column.at(j) == test_label )
             {
-                _catInCluster++;
+                labels_in_cluster++;
             }
         }
     }
 
-    return _catInCluster;
-}
-
-
-
-/*!
- * An interface to choose and run the correct tests on the pair.
- *
- * @param ccmPair The pair thats going to be tested.
- *
- * @param clusterIndex The cluster to test inside the pair, each cluster is
- *       tested.
- *
- * @param testIndex Which test we are currently performing.
- *
- * @param featureIndex The current feature we are testing.
- *
- * @param labelIndex The label in the feature we are running a test on.
- *
- * @param pValues The two dimensional array holding all of the results from the
- *       tests.
- *
- * @return The test that was just conducted.
- */
-int ConditionalTest::Serial::test(
-    CCMatrix::Pair& ccmPair,
-    qint32 clusterIndex,
-    qint32& testIndex,
-    qint32 featureIndex,
-    qint32 labelIndex,
-    QVector<QVector<double>>& pValues,
-    QVector<QVector<double>>& r2)
-{
-    EDEBUG_FUNC(this,&ccmPair, clusterIndex, &testIndex, featureIndex, labelIndex, &pValues);
-
-    // get informatiopn on the mask
-    clusterInfo(ccmPair, clusterIndex, _base->_features.at(featureIndex).at(labelIndex), _base->_testType.at(featureIndex));
-
-    // For linear regresssion we need a variable that will hold the
-    // pvalue and the r2 value.
-    QVector<double> results(2);
-
-    // conduct the correct test based on the type of data
-    switch(_base->_testType.at(featureIndex))
-    {
-        case CATEGORICAL:
-            pValues[clusterIndex][testIndex] = hypergeom(ccmPair, clusterIndex, _base->_features.at(featureIndex).at(labelIndex));
-            r2[clusterIndex][testIndex] = qQNaN();
-            testIndex++;
-            break;
-        case ORDINAL:
-            regression(_amxData, ccmPair, clusterIndex, ORDINAL, results);
-            pValues[clusterIndex][testIndex] = results.at(0);
-            r2[clusterIndex][testIndex] = results.at(1);
-            testIndex++;
-            break;
-        case QUANTITATIVE:
-            regression(_amxData, ccmPair, clusterIndex, QUANTITATIVE, results);
-            pValues[clusterIndex][testIndex] = results.at(0);
-            r2[clusterIndex][testIndex] = results.at(1);
-            testIndex++;
-            break;
-        default:
-            break;
-    }
-
-    return _base->_testType.at(featureIndex);
-}
-
-
-
-/*!
- * Run the first binomial test for given data.
- *
- * @return Pvalue corrosponding to the test.
- */
-double ConditionalTest::Serial::hypergeom(CCMatrix::Pair& ccmPair, int clusterIndex, QString test_label)
-{
-    EDEBUG_FUNC(this);
 
     // We use the hypergeometric distribution because the samples are
     // selected from the population for membership in the cluster without
@@ -294,13 +200,13 @@ double ConditionalTest::Serial::hypergeom(CCMatrix::Pair& ccmPair, int clusterIn
     int sampleSize =  _base->_emx->sampleSize();
 
     // Population contains n1 elements of Type 1.
-    int n1 = _catCount;
+    int n1 = label_count;
     // Population contains n2 elements of Type 2.
-    int n2 = sampleSize - _catCount;
+    int n2 = sampleSize - label_count;
     // k elements of Type 1 were selected.
-    int k = _catInCluster;
+    int k = labels_in_cluster;
     // t total elements were selected.
-    int t = _clusterSize;
+    int t = cluster_size;
     // Holds the pvalue
     double pvalue = 1;
 
@@ -353,7 +259,7 @@ double ConditionalTest::Serial::hypergeom(CCMatrix::Pair& ccmPair, int clusterIn
             // Now count the number of randomly selected items from the cluster.
             for ( int j = 0; j < bs_t; j++ )
             {
-                if ( ccmPair.at(clusterIndex, chosen[j]) == 1 && _amxData.at(chosen[j]) == test_label )
+                if ( ccmPair.at(clusterIndex, chosen[j]) == 1 && amx_column.at(chosen[j]) == test_label )
                 {
                     ns = ns + 1;
                 }
@@ -376,8 +282,8 @@ double ConditionalTest::Serial::hypergeom(CCMatrix::Pair& ccmPair, int clusterIn
         }
 
         // Now reset the sample size and the proporiton of success.
-        pvalue = gsl_cdf_hypergeometric_Q(jkap, n1, n2, bs_t);
-        return pvalue;
+        result = gsl_cdf_hypergeometric_Q(jkap, n1, n2, bs_t);
+        return;
     }
 
     // Since we want to test P(X >= k) not P(X > k) we should
@@ -389,27 +295,26 @@ double ConditionalTest::Serial::hypergeom(CCMatrix::Pair& ccmPair, int clusterIn
     }
 
     // The gsl_cdf_hypergeometric_Q function uses the upper-tail of the CDF.
-    pvalue = gsl_cdf_hypergeometric_Q(k, n1, n2, t);
-    return pvalue;
+    result = gsl_cdf_hypergeometric_Q(k, n1, n2, t);
+    return;
 }
 
 
 
 /*!
- * Run the regression test for given data, the regression line is genex vs geney vs label data.
- *
- * @param amxInfo Annotation matrix information.
- *
- * @param ccmPair Cluster matrix pair.
- *
- * @param clusterIndex The index of the cluster, used to get the right info
- *       from the cluster pair
- *
- * @return Pvalue corrosponding to the test.
+ * Performs the regression test for quantitative data.
  */
-void ConditionalTest::Serial::regression(QVector<QString> &amxInfo, CCMatrix::Pair& ccmPair, int clusterIndex, TestType testType, QVector<double>& results)
+void ConditionalTest::Serial::regression(CCMatrix::Pair& ccmPair, int clusterIndex, int featureIndex, QVector<double>& results)
 {
     EDEBUG_FUNC(this, &amxInfo, &ccmPair, clusterIndex);
+
+    // Get the column data from the annotation matrix.
+    int num_samples = _base->_data.at(featureIndex).size();
+    QVector<QString> amx_column(num_samples);
+    for ( int j = 0; j < num_samples; j++ )
+    {
+        amx_column[j] = _base->_data.at(featureIndex).at(j).toString();
+    }
 
     // Temp containers.
     QVector<double> labelInfo;
@@ -428,7 +333,7 @@ void ConditionalTest::Serial::regression(QVector<QString> &amxInfo, CCMatrix::Pa
         // If the sample label matches with the given label.
         if ( ccmPair.at(clusterIndex, i) == 1 )
         {
-            if (QString::compare(amxInfo.at(i), _base->_missing) == 0) {
+            if (QString::compare(amx_column.at(i), _base->_missing) == 0) {
                 continue;
             }
             test_cluster_size++;
@@ -463,7 +368,7 @@ void ConditionalTest::Serial::regression(QVector<QString> &amxInfo, CCMatrix::Pa
         if ( ccmPair.at(clusterIndex, i) == 1 )
         {
             // Skip samples with a missing value in the annotation matrix
-            if (QString::compare(amxInfo.at(i), _base->_missing) == 0) {
+            if (QString::compare(amx_column.at(i), _base->_missing) == 0) {
                 continue;
             }
 
@@ -478,7 +383,7 @@ void ConditionalTest::Serial::regression(QVector<QString> &amxInfo, CCMatrix::Pa
             gsl_matrix_set(X, j, 1, g1);
             gsl_matrix_set(X, j, 2, g2);
             gsl_matrix_set(X, j, 3, g1*g2);
-            gsl_vector_set(Y, j, amxInfo.at(i).toFloat());
+            gsl_vector_set(Y, j, amx_column.at(i).toFloat());
 
             j++;
         }

--- a/src/core/conditionaltest_serial.cpp
+++ b/src/core/conditionaltest_serial.cpp
@@ -249,8 +249,7 @@ int ConditionalTest::Serial::test(
     switch(_base->_testType.at(featureIndex))
     {
         case CATEGORICAL:
-            pValues[clusterIndex][testIndex] = hypergeom(ccmPair, clusterIndex,
-                                                         _base->_features.at(featureIndex).at(labelIndex));
+            pValues[clusterIndex][testIndex] = hypergeom(ccmPair, clusterIndex, _base->_features.at(featureIndex).at(labelIndex));
             r2[clusterIndex][testIndex] = qQNaN();
             testIndex++;
             break;

--- a/src/core/conditionaltest_serial.h
+++ b/src/core/conditionaltest_serial.h
@@ -17,44 +17,19 @@ public:
     virtual std::unique_ptr<EAbstractAnalyticBlock> execute(const EAbstractAnalyticBlock* block) override final;
 
     // helper functions
-    int test(CCMatrix::Pair& ccmPair, qint32 clusterIndex, qint32& testIndex, qint32 featureIndex, qint32 labelIndex, QVector<QVector<double>>& pValues, QVector<QVector<double>>& r2);
-    int prepAnxData(QString testLabel, int dataIndex, TestType testType);
     bool isEmpty(QVector<QVector<double>>& matrix);
-    int clusterInfo(CCMatrix::Pair& ccmPair, int clusterIndex, QString label, TestType testType);
 
-    // Binomial Tests
-    double binomial();
-    double testOne();
-    double testTwo();
-
-    // Hypergeometrix Test.
-    double hypergeom(CCMatrix::Pair& ccmPair, int clusterIndex, QString test_label);
-
-    // Regression Test
-    void regression(QVector<QString> &amxInfo, CCMatrix::Pair& ccmPair, int clusterIndex, TestType testType, QVector<double>& results);
-    double fTest(double chisq, gsl_matrix* X, gsl_vector* Y, gsl_matrix* cov, gsl_vector* C);
+    // Statistical Tests
+    void hypergeom(CCMatrix::Pair& ccmPair, int clusterIndex,
+                   int featureIndex, int labelIndex,  double& results);
+    void regression(CCMatrix::Pair& ccmPair, int clusterIndex,
+                    int featureIndex, QVector<double>& results);
 
 private:
     /*!
-     * Pointer to the serials objects parent KNNAnalytic.
+     * Pointer to the base analytic for this object.
      */
     ConditionalTest* _base;
-    /*!
-     * Annotation matrix data for testing.
-     */
-    QVector<QString> _amxData;
-    /*!
-     * Category count.
-     */
-    qint32 _catCount {0};
-    /*!
-     * Category count in cluster.
-     */
-    qint32 _catInCluster {0};
-    /*!
-     * Size of the cluster.
-     */
-    qint32 _clusterSize {0};
 };
 
 

--- a/src/core/conditionaltest_serial.h
+++ b/src/core/conditionaltest_serial.h
@@ -20,9 +20,9 @@ public:
     bool isEmpty(QVector<QVector<double>>& matrix);
 
     // Statistical Tests
-    void hypergeom(CCMatrix::Pair& ccmPair, int clusterIndex,
+    void hypergeom(QVector<QString> amx_column, CCMatrix::Pair& ccmPair, int clusterIndex,
                    int featureIndex, int labelIndex,  double& results);
-    void regression(CCMatrix::Pair& ccmPair, int clusterIndex,
+    void regression(QVector<QString> amx_column, CCMatrix::Pair& ccmPair, int clusterIndex,
                     int featureIndex, QVector<double>& results);
 
 private:

--- a/src/core/conditionaltest_serial.h
+++ b/src/core/conditionaltest_serial.h
@@ -20,10 +20,20 @@ public:
     bool isEmpty(QVector<QVector<double>>& matrix);
 
     // Statistical Tests
-    void hypergeom(QVector<QString> amx_column, CCMatrix::Pair& ccmPair, int clusterIndex,
-                   int featureIndex, int labelIndex,  double& results);
-    void regression(QVector<QString> amx_column, CCMatrix::Pair& ccmPair, int clusterIndex,
-                    int featureIndex, QVector<double>& results);
+    void hypergeom(
+        const QVector<QString>& amx_column,
+        const CCMatrix::Pair& ccmPair,
+        int clusterIndex,
+        int featureIndex,
+        int labelIndex,
+        double& results);
+    
+    void regression(
+        const QVector<QString>& amx_column,
+        const CCMatrix::Pair& ccmPair,
+        int clusterIndex,
+        int featureIndex,
+        QVector<double>& results);
 
 private:
     /*!

--- a/src/core/conditionspecificclustersmatrix.cpp
+++ b/src/core/conditionspecificclustersmatrix.cpp
@@ -13,7 +13,14 @@
  *
  * @param data All the data in the annotation matrix.
  */
-void CSMatrix::initialize(const EMetaArray& features, const QVector<EMetaArray>& featureInfo, const QVector<EMetaArray>& data, int& numTests, QString testNames)
+void CSMatrix::initialize(const EMetaArray& features,
+                          const QVector<EMetaArray>& featureInfo,
+                          const QVector<EMetaArray>& data,
+                          int numTests,
+                          QString testNames,
+                          const EMetaArray& geneNames,
+                          int maxClusterSize,
+                          int subheader)
 {
     EDEBUG_FUNC(this,&features,&featureInfo,&data);
 
@@ -42,35 +49,22 @@ void CSMatrix::initialize(const EMetaArray& features, const QVector<EMetaArray>&
     EMetaArray labels;
     EMetaObject info;
     EMetaObject feature;
-    int num_tests = 0;
 
-    // set the feature information in the meta data
+    // Set the feature information in the meta data
     for ( int i = 0; i < features.size(); i++ )
     {
-        // set the test type
+        // Set the test type
         type.insert("Type", featureInfo.at(i).at(0));
 
-        // set the labels
-        // Catagorical
+        // Set the labels
+        // Categorical
         if ( featureInfo.at(i).size() > 2 && featureInfo.at(i).at(0).toString() == "Categorical" )
         {
             for ( int j = 2; j < featureInfo.at(i).size(); j++ )
             {
                 labels.append(featureInfo.at(i).at(j));
-                if ( featureInfo.at(i).at(0).toString() != "None" && featureInfo.at(i).at(0).toString() != "Unknown" )
-                {
-                    ++num_tests;
-                }
             }
             info.insert("Labels", labels);
-        }
-        // Ordinal and Quantitative
-        else
-        {
-            if ( featureInfo.at(i).at(0).toString() != "None" && featureInfo.at(i).at(0).toString() != "Unknown" )
-            {
-                ++num_tests;
-            }
         }
         // create the labels and test drop bar aka label information
         info.insert("Test", type);
@@ -101,7 +95,6 @@ void CSMatrix::initialize(const EMetaArray& features, const QVector<EMetaArray>&
     metaObject.insert("Data", Data);
 
     // add num_tests
-    numTests += num_tests;
     _testcount = numTests;
     metaObject.insert("Number of Tests", numTests);
 
@@ -116,23 +109,6 @@ void CSMatrix::initialize(const EMetaArray& features, const QVector<EMetaArray>&
     // set the root of the meta data to the changed metaobject
     setMeta(metaObject);
     _sampleSize = sampleNames.size();
-}
-
-
-
-/*!
- * Writes the pairwise specific metadata.
- *
- * @param geneNames Names of all the genes in the gene expresion matrix.
- *
- * @param maxClusterSize Maximum amount of pairs a cell can have in the pairwise matrix,
- *                       system max is 64.
- *
- * @param subheader The size of the subheader, only contains the sample size.
- */
-void CSMatrix::initialize(const EMetaArray& geneNames, int maxClusterSize, int subheader)
-{
-    EDEBUG_FUNC(this,&geneNames,maxClusterSize,subheader);
 
     Matrix::initialize(geneNames, maxClusterSize, sizeof(double) * 2 * _testcount, subheader);
 }
@@ -191,20 +167,6 @@ void CSMatrix::readHeader()
     EDEBUG_FUNC(this);
 
     stream() >> _sampleSize >> _testcount;
-}
-
-
-
-/*!
- * Set the number of tests that are going to be ran.
- *
- * @param newData The number of tests you want to set the variable to.
- */
-void CSMatrix::setTestCount(qint32 newData)
-{
-    EDEBUG_FUNC(this, newData);
-
-    _testcount = newData;
 }
 
 

--- a/src/core/conditionspecificclustersmatrix.cpp
+++ b/src/core/conditionspecificclustersmatrix.cpp
@@ -13,14 +13,15 @@
  *
  * @param data All the data in the annotation matrix.
  */
-void CSMatrix::initialize(const EMetaArray& features,
-                          const QVector<EMetaArray>& featureInfo,
-                          const QVector<EMetaArray>& data,
-                          int numTests,
-                          QString testNames,
-                          const EMetaArray& geneNames,
-                          int maxClusterSize,
-                          int subheader)
+void CSMatrix::initialize(
+    const EMetaArray& features,
+    const QVector<EMetaArray>& featureInfo,
+    const QVector<EMetaArray>& data,
+    int numTests,
+    QString testNames,
+    const EMetaArray& geneNames,
+    int maxClusterSize,
+    int subheader)
 {
     EDEBUG_FUNC(this,&features,&featureInfo,&data);
 
@@ -180,7 +181,10 @@ void CSMatrix::readHeader()
  */
 QString CSMatrix::getTestName(int index) const
 {
-    return meta().toObject().at("Test Names").toArray().at(index).toString();
+    return meta()
+        .toObject().at("Test Names")
+        .toArray().at(index)
+        .toString();
 }
 
 
@@ -189,10 +193,12 @@ QString CSMatrix::getTestType(int index) const
 {
     auto names = getTestName(index).split("__");
 
-    return meta().toObject().at("Features")
-                 .toObject().at(names.at(0))
-                 .toObject().at("Test")
-                 .toObject().at("Type").toString();
+    return meta()
+        .toObject().at("Features")
+        .toObject().at(names.at(0))
+        .toObject().at("Test")
+        .toObject().at("Type")
+        .toString();
 }
 
 

--- a/src/core/conditionspecificclustersmatrix.h
+++ b/src/core/conditionspecificclustersmatrix.h
@@ -3,6 +3,7 @@
 #include "pairwise_matrix.h"
 
 
+
 /*!
  * This class implements the condition-specific results matrix data object. A correlation matrix
  * is a pairwise matrix where each pair-cluster element is a combination of two values: p-value
@@ -18,14 +19,15 @@ public:
 public:
     virtual QAbstractTableModel* model() override final;
 public:
-    void initialize(const EMetaArray& features,
-                    const QVector<EMetaArray>& featureInfo,
-                    const QVector<EMetaArray>& data,
-                    int numTests,
-                    QString testNames,
-                    const EMetaArray& geneNames,
-                    int maxClusterSize,
-                    int subheader);
+    void initialize(
+        const EMetaArray& features,
+        const QVector<EMetaArray>& featureInfo,
+        const QVector<EMetaArray>& data,
+        int numTests,
+        QString testNames,
+        const EMetaArray& geneNames,
+        int maxClusterSize,
+        int subheader);
 
     int sampleSize() const;
     QString getTestName(int index) const;

--- a/src/core/conditionspecificclustersmatrix.h
+++ b/src/core/conditionspecificclustersmatrix.h
@@ -18,12 +18,16 @@ public:
 public:
     virtual QAbstractTableModel* model() override final;
 public:
-    void initialize(const EMetaArray& geneNames, int maxClusterSize, int subheader);
-    void initialize(const EMetaArray& features, const QVector<EMetaArray>& featureInfo, const QVector<EMetaArray>& data, int& numTests, QString fileName);
+    void initialize(const EMetaArray& features,
+                    const QVector<EMetaArray>& featureInfo,
+                    const QVector<EMetaArray>& data,
+                    int numTests,
+                    QString testNames,
+                    const EMetaArray& geneNames,
+                    int maxClusterSize,
+                    int subheader);
 
     int sampleSize() const;
-    void setTestCount(qint32 newData);
-
     QString getTestName(int index) const;
 
     /*!


### PR DESCRIPTION
Description
========
This PR fixes issue #138.   To summarize, there was a bug if the `cond-test` analytic was used with MPI.  All of the clusters would have significant edges. This is because the p-value tests never ran because the class was not properly instantiated for the MPI slaves.  Since the p-value defaults to 0 it looked like everything was significant.  This only affected results if MPI was used.   

To fix this, I updated the initialize function of the ConditionTest class so that the slaves could initialize their instance of the class.   

Also, in the process of debugging this, I fixed a lot of weirdness in the code. It's a bit more streamlined in terms of layout now.  This weirdness did not affect the results. It just made the code harder to figure out. I think it's a bit easier now.  

Testing
=====
To test this PR, do the following prior to pulling this branch:
1.  Run the `example/kinc-gmm-run.sh` script to get correct results.  Save these results in a temp directory for later comparison
2.  Run the `example/kinc-gmm-mpirun.sh` script. You'll see that all of pairs have signficant tests with a p-value of 0.
3. Next pull this branch of the code and re-run step #2.  
4.  Compare the results of step #3 with step #1.  There will be a little bit of discrepancy but not much. The differences are due to issue #137 and all should be fine.

Additional Info
==========
@4ctrl-alt-del or @bentsherman would one of you look over the code to make sure I'm following design standards and I didn't do anything inappropriate with my edits.