### PR TITLE
Fixed bug with tidy format rearrangement. 

### DIFF
--- a/bin/kinc-filter-rank.R
+++ b/bin/kinc-filter-rank.R
@@ -88,9 +88,6 @@ net$rank = ranks
 # Filter the network to include the top n ranked edges.
 netF = net[(which(ranks < opt$top_n)),]
 netF = netF[order(netF$rank),]
-if (opt$strict) {
-    netF = netF[1:min(dim(netF)[1], opt$top_n),]
-}
 
 if (opt$save_condition_networks) {
     message("Saving filtered condition-specific networks...")

--- a/example/kinc-gmm-all-formats.sh
+++ b/example/kinc-gmm-all-formats.sh
@@ -1,0 +1,27 @@
+#!/bin/bash
+# Run this after any KINC run to extract the various formats.
+
+# Step 5: Extract the network.
+echo "Extracting the condition-specific network."
+
+p="1e-3"
+r2="0.30"
+th="0.00"
+
+formats="tidy minimal graphml text"
+
+for format in $formats; do
+
+  kinc run extract \
+    --emx "PRJNA301554.slim.GEM.log2.emx" \
+    --ccm "PRJNA301554.slim.GEM.log2.paf.ccm" \
+    --cmx "PRJNA301554.slim.GEM.log2.paf.cmx" \
+    --csm "PRJNA301554.slim.GEM.log2.paf.csm" \
+    --format $format \
+    --output "PRJNA301554.slim.GEM.log2.paf-th${th}-p${p}-rsqr${r2}.${format}.txt" \
+    --mincorr $th \
+    --maxcorr 1 \
+    --filter-pvalue $p \
+    --filter-rsquare $r2
+
+done;

--- a/src/core/extract_input.cpp
+++ b/src/core/extract_input.cpp
@@ -11,9 +11,10 @@
 const QStringList Extract::Input::FORMAT_NAMES
 {
     "text"
+    ,"tidy"
     ,"minimal"
     ,"graphml"
-    ,"tidy"
+
 };
 
 


### PR DESCRIPTION
This fixes issue #142.  The problem is that when someone specifies `tidy` they get `graphml` output instead. The problem is described on the issue.

This is the first PR to merge into the new `develop` branch.

To test this, just run the `kinc-gmm-run.sh` script inside of the `example` directory.  Run it before and after this fix with the `--format "tidy"` option.  Before the fix you get GraphML output, afterwards you get tidy output.

edit:  I added a new script to easily generate all output formats.  It's called `kinc-gmm-all-formats.sh`. You can run it after the `kinc-gmm-run.sh` and it will spit out all of the file formats for easy checking.