### PR TITLE
Fixes for too many missing values in a cluster

### DIFF
--- a/src/core/conditionaltest_input.cpp
+++ b/src/core/conditionaltest_input.cpp
@@ -49,6 +49,7 @@ EAbstractAnalyticInput::Type ConditionalTest::Input::type(int index) const
     case AMXINPUT: return FileIn;
     case Delimiter: return String;
     case MISSING: return String;
+    case NANToken: return String;
     case CSMOUT: return DataOut;
     case OVERRIDES: return String;
     case TEST: return String;
@@ -123,8 +124,17 @@ QVariant ConditionalTest::Input::data(int index, Role role) const
         {
         case CommandLineName: return QString("missing");
         case Title: return tr("Missing value:");
-        case WhatsThis: return tr("The string that specifies the missing value in the annotation matrix (e.g. NA, 0, 0.0).");
+        case WhatsThis: return tr("Deprecated. This option will work but may be removed in future versions. Please use --nan instead.");
         case Default: return tr("NA");
+        default: return QVariant();
+        }
+    case NANToken:
+        switch (role)
+        {
+        case Role::CommandLineName: return QString("nan");
+        case Role::Title: return tr("NAN Token:");
+        case Role::WhatsThis: return tr("The string that specifies the missing value in the annotation matrix (e.g. NA, 0, 0.0).");
+        case Role::Default: return "NA";
         default: return QVariant();
         }
     case CSMOUT:
@@ -174,6 +184,9 @@ void ConditionalTest::Input::set(int index, const QVariant& value)
     {
     case Delimiter:
         _base->_delimiter = value.toString();
+        break;
+    case NANToken:
+        _base->_missing = value.toString();
         break;
     case MISSING:
         _base->_missing = value.toString();

--- a/src/core/conditionaltest_input.h
+++ b/src/core/conditionaltest_input.h
@@ -19,7 +19,8 @@ public:
         ,CMXINPUT
         ,AMXINPUT
         ,Delimiter
-        ,MISSING
+        ,MISSING /** deprecated in favor of NANToken**/
+        ,NANToken
         ,CSMOUT
         ,TEST
         ,OVERRIDES

--- a/src/core/conditionaltest_serial.cpp
+++ b/src/core/conditionaltest_serial.cpp
@@ -345,6 +345,18 @@ void ConditionalTest::Serial::regression(
         }
     }
 
+    // Don't do regression analysis if there are fewer than 5 samples.
+    // This can occur if the annotation matrix has missing values
+    // for samples in the cluster. The Degrees of Freedom for the error
+    // is test_cluster_size - 4 so we need at least 5 samples. Odds
+    // are these tests will get filterd out anyway for low power.
+    if ( test_cluster_size < 5 )
+    {
+        results[0] = qQNaN();
+        results[1] = qQNaN();
+        return;
+    }
+
     // Allocate a matrix to hold the predictior variables, in this case the gene
     // Expression data.
     X = gsl_matrix_alloc(test_cluster_size, 4);
@@ -363,6 +375,7 @@ void ConditionalTest::Serial::regression(
     geneX.read(ccmPair.index().getX());
     geneY.read(ccmPair.index().getY());
 
+    // Useful for debugging purposes.
     // QString g1Name = geneX.toString();
     // QString g2Name = geneY.toString();
 
@@ -460,8 +473,8 @@ void ConditionalTest::Serial::regression(
     // Set the results array
     if ( qIsNaN(pValue) )
     {
-        results[0] = 1;
-        results[1] = 0;
+        results[0] = qQNaN();
+        results[1] = qQNaN();
     }
     else {
         results[0] = pValue;

--- a/src/core/conditionaltest_serial.cpp
+++ b/src/core/conditionaltest_serial.cpp
@@ -198,6 +198,14 @@ void ConditionalTest::Serial::hypergeom(
         }
     }
 
+    // If there are no matching labels in this cluster then return. This
+    // could happen if the annotation matrix has all NAs for the cluster.
+    if ( labels_in_cluster == 0 )
+    {
+        result = qQNaN();
+        return;
+    }
+
 
     // We use the hypergeometric distribution because the samples are
     // selected from the population for membership in the cluster without

--- a/src/core/importexpressionmatrix_input.cpp
+++ b/src/core/importexpressionmatrix_input.cpp
@@ -86,7 +86,7 @@ QVariant ImportExpressionMatrix::Input::data(int index, Role role) const
         {
         case Role::CommandLineName: return QString("nan");
         case Role::Title: return tr("NAN Token:");
-        case Role::WhatsThis: return tr("Expected token for expressions that have no value.");
+        case Role::WhatsThis: return tr("The string that specifies the missing value in the annotation matrix (e.g. NA, 0, 0.0).");
         case Role::Default: return "NA";
         default: return QVariant();
         }


### PR DESCRIPTION
This is a fix for issue #141.  If a cluster (edge) has so many missing values that there are too few samples left in the cluster then both the regression and the hypergeometric tests will throw a GSL error.  This PR fixes both.

However, there may still be another problem as @JohnHadish posted was this:
```
gsl: init_source.c:29: ERROR: matrix dimension n1 must be positive integer
```
That error indicates a problem with  the `n1` variable which is part of the hypergeometric test, not regression, but it was my understanding that the column is quantitative not categorical and regression should have been used....  

@JohnHadish I think this PR should fix the issue for both tests, but can you test it and make sure the output for quantitative columns is from regression testing and not categorical?

edit:  This PR also fixes issue #140  as well.  It uses the same `--nan` argument for consistency.  The `--missing` argument is still supported so as not to break existing scripts, but is deprecated.