### PR TITLE
Fix for ccm and cmx out of sync

### DIFF
--- a/src/core/conditionaltest.cpp
+++ b/src/core/conditionaltest.cpp
@@ -47,10 +47,16 @@ std::unique_ptr<EAbstractAnalyticBlock> ConditionalTest::makeWork(int index) con
 
     // initialize pairwise iterator for cmx file
     CorrelationMatrix::Pair cmxPair(_cmx);
+    if (index == 0)
+    {
+        cmxPair.readFirst();
+    }
+    else
+    {
+        cmxPair.read(Pairwise::Index(start));
+    }
 
-    // iterate to the start index of the next work block
-    cmxPair.read(Pairwise::Index(start));
-
+    // Iterate to the start index of the next work block
     for ( qint64 i = 0; i < size; i++ )
     {
         cmxPair.readNext();
@@ -134,6 +140,7 @@ void ConditionalTest::process(const EAbstractAnalyticBlock* result)
         {
             csmPair.write(pair.index);
         }
+
     }
 }
 

--- a/src/core/conditionaltest_serial.cpp
+++ b/src/core/conditionaltest_serial.cpp
@@ -57,10 +57,12 @@ std::unique_ptr<EAbstractAnalyticBlock> ConditionalTest::Serial::execute(const E
     // iterate through each pair in the work block
     for ( qint64 wbIndex = 0; wbIndex < workBlock->size(); ++wbIndex )
     {
+
         // print warning if iterator indices do not match
         if ( ccmPair.index() != cmxPair.index() )
         {
-            qInfo() << "warning: ccm and cmx files are out of sync";
+            qInfo() << "warning: ccm and cmx files are out of sync at cmx coordinate ("
+                    << cmxPair.index().getX() << "," << cmxPair.index().getY() <<").";
         }
 
         // initialize set of p values and r2 values for each cluster
@@ -117,14 +119,14 @@ std::unique_ptr<EAbstractAnalyticBlock> ConditionalTest::Serial::execute(const E
 
         // append pair to result block
         resultBlock->append(Pair {
-            ccmPair.index(),
+            cmxPair.index(),
             pValues,
             r2
         });
 
         // read the next pair
-        ccmPair.readNext();
         cmxPair.readNext();
+        ccmPair.read(cmxPair.index());
     }
 
     return std::unique_ptr<EAbstractAnalyticBlock>(resultBlock);
@@ -422,7 +424,6 @@ void ConditionalTest::Serial::test_proportions (
     {
         // Keeps track of the number of successes for each iteration.
         int ns = 0;
-        int fs = 0;
 
         // The gsl_ran_sample function randomly chooses samples with replacement from a list.
         int chosen[bs_t];
@@ -431,7 +432,6 @@ void ConditionalTest::Serial::test_proportions (
         // Now count the number of randomly selected items from the cluster.
         for ( int j = 0; j < bs_t; j++ )
         {
-            int etype = ccmPair.at(clusterIndex, chosen[j]);
             QString slabel = amx_column.at(chosen[j]);
             if ( ccmPair.at(clusterIndex, chosen[j]) == 1 && amx_column.at(chosen[j]) == test_label )
             {

--- a/src/core/corrpower.cpp
+++ b/src/core/corrpower.cpp
@@ -47,10 +47,16 @@ std::unique_ptr<EAbstractAnalyticBlock> CorrPowerFilter::makeWork(int index) con
 
     // initialize pairwise iterator for cmx file
     CorrelationMatrix::Pair cmxPair(_cmx);
+    if (index == 0)
+    {
+        cmxPair.readFirst();
+    }
+    else
+    {
+        cmxPair.read(Pairwise::Index(start));
+    }
 
-    // iterate to the start index of the next work block
-    cmxPair.read(Pairwise::Index(start));
-
+    // Iterate to the start index of the next work block
     for ( qint64 i = 0; i < size; i++ )
     {
         cmxPair.readNext();
@@ -58,6 +64,7 @@ std::unique_ptr<EAbstractAnalyticBlock> CorrPowerFilter::makeWork(int index) con
 
     // save start index of next work block
     _workBlockStart = cmxPair.index().toRawIndex();
+
 
     // construct work block
     return std::unique_ptr<EAbstractAnalyticBlock>(new WorkBlock(index, start, size));

--- a/src/core/corrpower_serial.cpp
+++ b/src/core/corrpower_serial.cpp
@@ -59,10 +59,12 @@ std::unique_ptr<EAbstractAnalyticBlock> CorrPowerFilter::Serial::execute(const E
     // Iterate through each pair in the work block.
     for ( qint64 wbIndex = 0; wbIndex < workBlock->size(); ++wbIndex )
     {
+
         // Print warning if iterator indices do not match
         if ( ccmPair.index() != cmxPair.index() )
         {
-            qInfo() << "warning: ccm and cmx files are out of sync";
+            qInfo() << "warning: ccm and cmx files are out of sync at cmx coordinate ("
+                    << cmxPair.index().getX() << "," << cmxPair.index().getY() <<").";
         }
 
         // Get the number of samples and clusters.
@@ -128,7 +130,7 @@ std::unique_ptr<EAbstractAnalyticBlock> CorrPowerFilter::Serial::execute(const E
         if ( new_correlations.size() > 0 )
         {
             resultBlock->append(Pair {
-                ccmPair.index(),
+                cmxPair.index(),
                 new_labels,
                 new_correlations,
                 k_keep
@@ -136,8 +138,9 @@ std::unique_ptr<EAbstractAnalyticBlock> CorrPowerFilter::Serial::execute(const E
         }
 
         // read the next pair
-        ccmPair.readNext();
         cmxPair.readNext();
+        ccmPair.read(cmxPair.index());
+
     }
 
     // We're done! Return the result block.

--- a/src/core/extract_networkwriter.cpp
+++ b/src/core/extract_networkwriter.cpp
@@ -54,7 +54,8 @@ int Extract::NetworkWriter::readNext()
 
         if ( _cmxPair.index() != _ccmPair.index() )
         {
-            qInfo() << "warning: cmx and ccm are out of sync";
+            qInfo() << "warning: cmx and ccm are out of sync at cmx coordinate ("
+                    << _cmxPair.index().getX() << "," << _cmxPair.index().getY() <<").";
         }
     }
 
@@ -65,7 +66,8 @@ int Extract::NetworkWriter::readNext()
 
         if ( _cmxPair.index() != _csmPair.index() )
         {
-            qInfo() << "warning: cmx and ccm are out of sync";
+            qInfo() << "warning: cmx and ccm are out of sync at cmx coordinate ("
+                    << _cmxPair.index().getX() << "," << _cmxPair.index().getY() <<").";
         }
     }
 

--- a/src/core/extract_networkwriter.cpp
+++ b/src/core/extract_networkwriter.cpp
@@ -44,13 +44,19 @@ int Extract::NetworkWriter::readNext()
 {
     EDEBUG_FUNC(this,cmx_index);
 
-    // read the next pair in the cmx
-    _cmxPair.readNext();
+    // Read the next pair in the cmx.
+    if(_cmxPair.index().toRawIndex() == 0)
+    {
+        _cmxPair.readFirst();
+    }
+    else {
+        _cmxPair.readNext();
+    }
 
     // read the next pair in the ccm (should always match cmx)
     if ( _ccm )
     {
-        _ccmPair.readNext();
+        _ccmPair.read(_cmxPair.index());
 
         if ( _cmxPair.index() != _ccmPair.index() )
         {
@@ -62,7 +68,7 @@ int Extract::NetworkWriter::readNext()
     // read the next pair in the csm (should always match cmx)
     if ( _csm )
     {
-        _csmPair.readNext();
+        _csmPair.read(_cmxPair.index());
 
         if ( _cmxPair.index() != _csmPair.index() )
         {

--- a/src/core/pairwise_matrix_pair.cpp
+++ b/src/core/pairwise_matrix_pair.cpp
@@ -44,8 +44,10 @@ void Matrix::Pair::write(const Index& index)
  * Read the pair with the given pairwise index from the data object file.
  *
  * @param index
+ *
+ * @return the index of the pair. If no pair is found at this index then -1 is returned.
  */
-void Matrix::Pair::read(const Index& index) const
+qint64 Matrix::Pair::read(const Index& index) const
 {
     EDEBUG_FUNC(this,&index);
 
@@ -61,8 +63,25 @@ void Matrix::Pair::read(const Index& index) const
         _rawIndex = clusterIndex;
         readNext();
     }
-}
+    return clusterIndex;
 
+}
+/*!
+ * For sparse matricies the index of the first pair may not be know.
+ *
+ * This function is used to find that first pair and read it.
+ */
+void Matrix::Pair::readFirst() const
+{
+    EDEBUG_FUNC(this);
+
+    for (qint64 i = 0; i < _cMatrix->size(); i++)
+    {
+        if (this->read(Pairwise::Index(i)) != -1) {
+            return;
+        }
+    }
+}
 
 
 /*!

--- a/src/core/pairwise_matrix_pair.cpp
+++ b/src/core/pairwise_matrix_pair.cpp
@@ -66,6 +66,9 @@ qint64 Matrix::Pair::read(const Index& index) const
     return clusterIndex;
 
 }
+
+
+
 /*!
  * For sparse matricies the index of the first pair may not be know.
  *

--- a/src/core/pairwise_matrix_pair.h
+++ b/src/core/pairwise_matrix_pair.h
@@ -32,8 +32,9 @@ namespace Pairwise
         virtual int clusterSize() const = 0;
         virtual bool isEmpty() const = 0;
         void write(const Index& index);
-        void read(const Index& index) const;
+        qint64 read(const Index& index) const;
         void reset() const { _rawIndex = 0; }
+        void readFirst() const;
         void readNext() const;
         bool hasNext() const { return _rawIndex != _cMatrix->_clusterSize; }
         const Index& index() const { return _index; }


### PR DESCRIPTION
This PR fixes issue #157.   The problem potentially occurs with the `corrpower` or `cond-test`  analytics, but can only happen in either case with a sparse matrix.  The problem is if the cmx or ccm files are sparse, the processing of pairs is not starting at the first pair.  It doesn't create incorrect results, it just offsets the counting in the for loops which causes the ccm to have fewer pairs than the original cmx.   The unfortunate side effect, other than the warning message is that a few potential edges may be missing from the output files after an `extract`.

This code fixes that problem by adding a new function `Matrix::Pair::readFirst()` which allows each analytic to first find the first real pair in a sparse matrix before beginning the first work block.  I also adjusted the code a bit to ensure that if there ever was another future problem with pairs missing in one file that moving between pairs in a files can recover in the event of an out of sync problem.