### PR TITLE
Docker update

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -4,6 +4,7 @@ MAINTAINER Ben Shealy <btsheal@clemson.edu>
 ARG NVIDIA_HEADLESS=0
 ARG ACE_REVISION="develop"
 ARG KINC_REVISION="develop"
+ARG KINC_R_REVISION="master"
 
 ENV CUDADIR="/usr/local/cuda"
 ENV CPLUS_INCLUDE_PATH="${CUDADIR}/include:${CPLUS_INCLUDE_PATH}"
@@ -24,7 +25,8 @@ RUN apt-get update -qq \
 		ocl-icd-opencl-dev \
 		python3-pip
 
-# install headless driver for cpu image
+
+# Install headless driver for cpu image
 RUN if [ ${NVIDIA_HEADLESS} = 1 ]; then apt-get install -qq -y nvidia-headless-418 ; fi
 
 # add NVIDIA platform to OpenCL
@@ -61,7 +63,7 @@ WORKDIR /opt
 RUN if [ "${KINC_REVISION}" = "v3.3.x" ] || [ "${KINC_REVISION}" = "v3.2.x" ] ; then \
         git clone -q https://github.com/SystemsGenetics/KINC.git \
         && cd KINC/build \
-    	&& git checkout -q ${KINC_REVISION} \
+    	&& git checkout-q ${KINC_REVISION} \
     	&& qmake ../src/KINC.pro \
     	&& make -s -j $(nproc) \
     	&& make -s qmake_all \
@@ -74,10 +76,43 @@ RUN if [ "${KINC_REVISION}" = "v3.3.x" ] || [ "${KINC_REVISION}" = "v3.2.x" ] ; 
     	&& make -s install; \
     fi
 
+
+# Add in a few additional requirements for the 3.4 version of KINC. These are needed
+# for the R and Python scripts in the bin folder.
+RUN if [ ! "${KINC_REVISION}" = "v3.3.x" ] && [ ! "${KINC_REVISION}" = "v3.2.x" ] ; then \
+    apt-get install -qq -y \
+        m4 \
+        autoconf \
+        automake \
+        libxml2-dev \
+        bison \
+        flex \
+        r-base; \
+    fi
+
+# Install KINC.R
+RUN if [ ! "${KINC_REVISION}" = "v3.3.x" ] && [ ! "${KINC_REVISION}" = "v3.2.x" ] ; then \
+      R -e "install.packages('devtools',dependencies=TRUE, repos='http://cran.rstudio.com/')" \
+      && R -e "install_github('SystemsGenetics/KINC.R', ref="${KINC_R_REVISION}")"; \
+    fi
+
+
 # install python dependencies
 WORKDIR /opt/KINC
 
-RUN pip3 install -q -r requirements.txt
+RUN pip3 install  -r requirements.txt
+
+
 
 # initialize default work directory
 WORKDIR /workspace
+
+# Tini for signal processing and zombie killing.
+ENV TINI_VERSION v0.18.0
+ADD https://github.com/krallin/tini/releases/download/${TINI_VERSION}/tini /tini
+RUN chmod +x /tini
+
+
+# Define the command and parameters that will be executed when this
+# container is first run.
+ENTRYPOINT ["/tini", "--"]

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -48,7 +48,7 @@ WORKDIR /opt
 RUN git clone -q https://github.com/SystemsGenetics/ACE.git \
 	&& cd ACE/build \
 	&& git checkout -q ${ACE_REVISION} \
-	&& qmake ../src/ACE.pro \
+	&& qmake ../src/ACE.pro GUI=no \
 	&& make -s -j $(nproc) \
 	&& make -s qmake_all \
 	&& make -s install
@@ -60,10 +60,10 @@ WORKDIR /opt
 
 # For older version of KINC we need to use qmake. For newer versions after 3.3.x we
 # can use the make file in the root directory of KINC.
-RUN if [ "${KINC_REVISION}" = "v3.3.x" ] || [ "${KINC_REVISION}" = "v3.2.x" ] ; then \
+RUN if [ "${KINC_REVISION}" =~ v3.3.[0-9] ] || [ "${KINC_REVISION}" =~ v3.2.[0-9] ] ; then \
         git clone -q https://github.com/SystemsGenetics/KINC.git \
         && cd KINC/build \
-    	&& git checkout-q ${KINC_REVISION} \
+    	&& git checkout -q ${KINC_REVISION} \
     	&& qmake ../src/KINC.pro \
     	&& make -s -j $(nproc) \
     	&& make -s qmake_all \
@@ -79,7 +79,7 @@ RUN if [ "${KINC_REVISION}" = "v3.3.x" ] || [ "${KINC_REVISION}" = "v3.2.x" ] ; 
 
 # Add in a few additional requirements for the >=3.4 version of KINC. These are needed
 # for the R and Python scripts in the bin folder.
-RUN if [ ! "${KINC_REVISION}" = "v3.3.x" ] && [ ! "${KINC_REVISION}" = "v3.2.x" ] ; then \
+RUN if [ "${KINC_REVISION}" =~ v3.3.[0-9] ] || [ "${KINC_REVISION}" =~ v3.2.[0-9] ] ; then \
     apt-get install -qq -y \
         m4 \
         autoconf \
@@ -95,7 +95,7 @@ RUN if [ ! "${KINC_REVISION}" = "v3.3.x" ] && [ ! "${KINC_REVISION}" = "v3.2.x" 
 
 # Install KINC.R
 ENV DEBIAN_FRONTEND=noninteractive
-RUN if [ ! "${KINC_REVISION}" = "v3.3.x" ] && [ ! "${KINC_REVISION}" = "v3.2.x" ] ; then \
+RUN if [ "${KINC_REVISION}" =~ v3.3.[0-9] ] || [ "${KINC_REVISION}" =~ v3.2.[0-9] ] ; then \
         apt-key adv --keyserver keyserver.ubuntu.com --recv-keys E298A3A825C0D65DFD57CBB651716619E084DAB9 \
         && add-apt-repository 'deb https://cloud.r-project.org/bin/linux/ubuntu bionic-cran40/' \
         && apt update \
@@ -104,7 +104,7 @@ RUN if [ ! "${KINC_REVISION}" = "v3.3.x" ] && [ ! "${KINC_REVISION}" = "v3.2.x" 
 
     fi
 
-RUN if [ ! "${KINC_REVISION}" = "v3.3.x" ] && [ ! "${KINC_REVISION}" = "v3.2.x" ] ; then \
+RUN if [ "${KINC_REVISION}" =~ v3.3.[0-9] ] || [ "${KINC_REVISION}" =~ v3.2.[0-9] ] ; then \
         R -e "library('devtools'); install_github('SystemsGenetics/KINC.R', ref='${KINC_R_REVISION}')"; \
     fi
 
@@ -119,7 +119,7 @@ RUN pip3 install  -r requirements.txt
 WORKDIR /workspace
 
 # Tini for signal processing and zombie killing.
-ENV TINI_VERSION v0.18.0
+ENV TINI_VERSION v0.19.0
 ADD https://github.com/krallin/tini/releases/download/${TINI_VERSION}/tini /tini
 RUN chmod +x /tini
 

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -48,7 +48,7 @@ WORKDIR /opt
 RUN git clone -q https://github.com/SystemsGenetics/ACE.git \
 	&& cd ACE/build \
 	&& git checkout -q ${ACE_REVISION} \
-	&& qmake ../src/ACE.pro GUI=no \
+	&& qmake ../src/ACE.pro \
 	&& make -s -j $(nproc) \
 	&& make -s qmake_all \
 	&& make -s install
@@ -60,26 +60,27 @@ WORKDIR /opt
 
 # For older version of KINC we need to use qmake. For newer versions after 3.3.x we
 # can use the make file in the root directory of KINC.
-RUN if [ "${KINC_REVISION}" =~ v3.3.[0-9] ] || [ "${KINC_REVISION}" =~ v3.2.[0-9] ] ; then \
-        git clone -q https://github.com/SystemsGenetics/KINC.git \
-        && cd KINC/build \
-    	&& git checkout -q ${KINC_REVISION} \
-    	&& qmake ../src/KINC.pro \
-    	&& make -s -j $(nproc) \
-    	&& make -s qmake_all \
-    	&& make -s install; \
-    else \
-        git clone -q https://github.com/SystemsGenetics/KINC.git \
-        && cd KINC \
-    	&& git checkout -q ${KINC_REVISION} \
-    	&& make -s -j $(nproc) \
-    	&& make -s install; \
-    fi
+RUN if echo "${KINC_REVISION}" | grep -Eq 'v3\.[32]\.[0-9]$' ; then \
+    git clone -q https://github.com/SystemsGenetics/KINC.git \
+    && cd KINC \
+	&& git checkout -q ${KINC_REVISION} \
+    && cd build \
+	&& qmake ../src/KINC.pro \
+	&& make -s -j $(nproc) \
+	&& make -s qmake_all \
+	&& make -s install; \
+else \
+    git clone -q https://github.com/SystemsGenetics/KINC.git \
+    && cd KINC \
+	&& git checkout -q ${KINC_REVISION} \
+	&& make -s -j $(nproc) \
+	&& make -s install; \
+fi
 
 
 # Add in a few additional requirements for the >=3.4 version of KINC. These are needed
 # for the R and Python scripts in the bin folder.
-RUN if [ "${KINC_REVISION}" =~ v3.3.[0-9] ] || [ "${KINC_REVISION}" =~ v3.2.[0-9] ] ; then \
+RUN if ! echo "${KINC_REVISION}" | grep -Eq 'v3\.[32]\.[0-9]$' ; then \
     apt-get install -qq -y \
         m4 \
         autoconf \
@@ -91,27 +92,23 @@ RUN if [ "${KINC_REVISION}" =~ v3.3.[0-9] ] || [ "${KINC_REVISION}" =~ v3.2.[0-9
         libcurl4-gnutls-dev \
         libssl-dev \
         software-properties-common; \
-    fi
+fi
 
 # Install KINC.R
 ENV DEBIAN_FRONTEND=noninteractive
-RUN if [ "${KINC_REVISION}" =~ v3.3.[0-9] ] || [ "${KINC_REVISION}" =~ v3.2.[0-9] ] ; then \
-        apt-key adv --keyserver keyserver.ubuntu.com --recv-keys E298A3A825C0D65DFD57CBB651716619E084DAB9 \
-        && add-apt-repository 'deb https://cloud.r-project.org/bin/linux/ubuntu bionic-cran40/' \
-        && apt update \
-        && apt-get -qq install -y r-base \
-        && R -q -e "install.packages('devtools', dependencies=TRUE, repos='http://cran.us.r-project.org')"; \
-
-    fi
-
-RUN if [ "${KINC_REVISION}" =~ v3.3.[0-9] ] || [ "${KINC_REVISION}" =~ v3.2.[0-9] ] ; then \
-        R -e "library('devtools'); install_github('SystemsGenetics/KINC.R', ref='${KINC_R_REVISION}')"; \
-    fi
+RUN if ! echo "${KINC_REVISION}" | grep -Eq 'v3\.[32]\.[0-9]$' ; then \
+    apt-key adv --keyserver keyserver.ubuntu.com --recv-keys E298A3A825C0D65DFD57CBB651716619E084DAB9 \
+    && add-apt-repository 'deb https://cloud.r-project.org/bin/linux/ubuntu bionic-cran40/' \
+    && apt-get update -qq \
+    && apt-get -qq install -y r-base \
+    && R -q -e "install.packages('devtools', dependencies=TRUE, repos='http://cran.us.r-project.org')" \
+    && R -e "library('devtools'); install_github('SystemsGenetics/KINC.R', ref='${KINC_R_REVISION}')"; \
+fi
 
 # install python dependencies
 WORKDIR /opt/KINC
 
-RUN pip3 install  -r requirements.txt
+RUN if [ -e requirements.txt ]; then pip3 install  -r requirements.txt; fi
 
 
 

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -77,7 +77,7 @@ RUN if [ "${KINC_REVISION}" = "v3.3.x" ] || [ "${KINC_REVISION}" = "v3.2.x" ] ; 
     fi
 
 
-# Add in a few additional requirements for the 3.4 version of KINC. These are needed
+# Add in a few additional requirements for the >=3.4 version of KINC. These are needed
 # for the R and Python scripts in the bin folder.
 RUN if [ ! "${KINC_REVISION}" = "v3.3.x" ] && [ ! "${KINC_REVISION}" = "v3.2.x" ] ; then \
     apt-get install -qq -y \
@@ -87,15 +87,26 @@ RUN if [ ! "${KINC_REVISION}" = "v3.3.x" ] && [ ! "${KINC_REVISION}" = "v3.2.x" 
         libxml2-dev \
         bison \
         flex \
-        r-base; \
+        build-essential \
+        libcurl4-gnutls-dev \
+        libssl-dev \
+        software-properties-common; \
     fi
 
 # Install KINC.R
+ENV DEBIAN_FRONTEND=noninteractive
 RUN if [ ! "${KINC_REVISION}" = "v3.3.x" ] && [ ! "${KINC_REVISION}" = "v3.2.x" ] ; then \
-      R -e "install.packages('devtools',dependencies=TRUE, repos='http://cran.rstudio.com/')" \
-      && R -e "install_github('SystemsGenetics/KINC.R', ref="${KINC_R_REVISION}")"; \
+        apt-key adv --keyserver keyserver.ubuntu.com --recv-keys E298A3A825C0D65DFD57CBB651716619E084DAB9 \
+        && add-apt-repository 'deb https://cloud.r-project.org/bin/linux/ubuntu bionic-cran40/' \
+        && apt update \
+        && apt-get -qq install -y r-base \
+        && R -q -e "install.packages('devtools', dependencies=TRUE, repos='http://cran.us.r-project.org')"; \
+
     fi
 
+RUN if [ ! "${KINC_REVISION}" = "v3.3.x" ] && [ ! "${KINC_REVISION}" = "v3.2.x" ] ; then \
+        R -e "library('devtools'); install_github('SystemsGenetics/KINC.R', ref='${KINC_R_REVISION}')"; \
+    fi
 
 # install python dependencies
 WORKDIR /opt/KINC

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -43,11 +43,10 @@ RUN git clone -q https://github.com/kthohr/stats \
 # install ACE
 WORKDIR /opt
 
-ADD https://api.github.com/repos/SystemsGenetics/ACE/git/refs/heads/${ACE_REVISION} ace-version.json
 RUN git clone -q https://github.com/SystemsGenetics/ACE.git \
 	&& cd ACE/build \
 	&& git checkout -q ${ACE_REVISION} \
-	&& qmake ../src/ACE.pro GUI=no \
+	&& qmake ../src/ACE.pro \
 	&& make -s -j $(nproc) \
 	&& make -s qmake_all \
 	&& make -s install
@@ -57,15 +56,23 @@ ENV LD_LIBRARY_PATH "/usr/local/lib:$LD_LIBRARY_PATH"
 # install KINC
 WORKDIR /opt
 
-ADD https://api.github.com/repos/SystemsGenetics/KINC/git/refs/heads/${KINC_REVISION} kinc-version.json
-RUN git clone -q https://github.com/SystemsGenetics/KINC.git \
-	&& mkdir -p KINC/build \
-	&& cd KINC/build \
-	&& git checkout -q ${KINC_REVISION} \
-	&& qmake ../src/KINC.pro GUI=no \
-	&& make -s -j $(nproc) \
-	&& make -s qmake_all \
-	&& make -s install
+# For older version of KINC we need to use qmake. For newer versions after 3.3.x we
+# can use the make file in the root directory of KINC.
+RUN if [ "${KINC_REVISION}" = "v3.3.x" ] || [ "${KINC_REVISION}" = "v3.2.x" ] ; then \
+        git clone -q https://github.com/SystemsGenetics/KINC.git \
+        && cd KINC/build \
+    	&& git checkout -q ${KINC_REVISION} \
+    	&& qmake ../src/KINC.pro \
+    	&& make -s -j $(nproc) \
+    	&& make -s qmake_all \
+    	&& make -s install; \
+    else \
+        git clone -q https://github.com/SystemsGenetics/KINC.git \
+        && cd KINC \
+    	&& git checkout -q ${KINC_REVISION} \
+    	&& make -s -j $(nproc) \
+    	&& make -s install; \
+    fi
 
 # install python dependencies
 WORKDIR /opt/KINC

--- a/docker/Makefile
+++ b/docker/Makefile
@@ -11,7 +11,7 @@ latest:
 		-t systemsgenetics/kinc:latest-gpu \
 		--build-arg NVIDIA_HEADLESS=0 \
 		--build-arg ACE_REVISION=v3.2.0 \
-		--build-arg KINC_REVISION=develop \
+		--build-arg KINC_REVISION=docker-update \
 		.
 
 v3.4.x:

--- a/docker/Makefile
+++ b/docker/Makefile
@@ -4,13 +4,13 @@ latest:
 	docker build \
 		-t systemsgenetics/kinc:latest-cpu \
 		--build-arg NVIDIA_HEADLESS=1 \
-		--build-arg ACE_REVISION=develop \
+		--build-arg ACE_REVISION=v3.2.0 \
 		--build-arg KINC_REVISION=develop \
 		.
 	docker build \
 		-t systemsgenetics/kinc:latest-gpu \
 		--build-arg NVIDIA_HEADLESS=0 \
-		--build-arg ACE_REVISION=develop \
+		--build-arg ACE_REVISION=v3.2.0 \
 		--build-arg KINC_REVISION=develop \
 		.
 
@@ -19,13 +19,13 @@ v3.4.x:
 		-t systemsgenetics/kinc:3.4.2-cpu \
 		--build-arg NVIDIA_HEADLESS=1 \
 		--build-arg ACE_REVISION=v3.2.0 \
-		--build-arg KINC_REVISION=v3.4.2 \
+		--build-arg KINC_REVISION=develop \
 		.
 	docker build \
 		-t systemsgenetics/kinc:3.4.2-gpu \
 		--build-arg NVIDIA_HEADLESS=0 \
 		--build-arg ACE_REVISION=v3.2.0 \
-		--build-arg KINC_REVISION=v3.4.2 \
+		--build-arg KINC_REVISION=develop \
 		.
 
 v3.3.x:

--- a/docker/Makefile
+++ b/docker/Makefile
@@ -1,22 +1,49 @@
-all: latest v3.4.x v3.3.x v3.2.x
+all: develop latest v3.4.x v3.3.x v3.2.x
 
-latest:
+develop: develop-cpu develop-gpu
+
+develop-cpu:
+	docker build \
+            -t systemsgenetics/kinc:develop-cpu \
+            --build-arg NVIDIA_HEADLESS=1 \
+            --build-arg ACE_REVISION=v3.2.0 \
+            --build-arg KINC_REVISION=develop \
+            --build-arg KINC_R_REVISION=v1.2 \
+            .
+
+develop-gpu:
+    docker build \
+            -t systemsgenetics/kinc:develop-gpu \
+            --build-arg NVIDIA_HEADLESS=0 \
+            --build-arg ACE_REVISION=v3.2.0 \
+            --build-arg KINC_REVISION=develop \
+            --build-arg KINC_R_REVISION=v1.2 \
+            .
+
+
+latest: latest-cpu latest-gpu
+
+latest-cpu:
 	docker build \
 		-t systemsgenetics/kinc:latest-cpu \
 		--build-arg NVIDIA_HEADLESS=1 \
 		--build-arg ACE_REVISION=v3.2.0 \
-		--build-arg KINC_REVISION=develop \
+		--build-arg KINC_REVISION=v3.4.2 \
 		--build-arg KINC_R_REVISION=v1.2 \
 		.
+
+latest-gpu:
 	docker build \
 		-t systemsgenetics/kinc:latest-gpu \
 		--build-arg NVIDIA_HEADLESS=0 \
 		--build-arg ACE_REVISION=v3.2.0 \
-		--build-arg KINC_REVISION=develop \
+		--build-arg KINC_REVISION=v3.4.2 \
 		--build-arg KINC_R_REVISION=v1.2 \
 		.
 
-v3.4.x:
+v3.4.x: v3.4.x-cpu v3.4.x-gpu
+
+v3.4.x-cpu:
 	docker build \
 		-t systemsgenetics/kinc:3.4.2-cpu \
 		--build-arg NVIDIA_HEADLESS=1 \
@@ -24,6 +51,8 @@ v3.4.x:
 		--build-arg KINC_REVISION=v3.4.2 \
 		--build-arg KINC_R_REVISION=v1.2 \
 		.
+
+v3.4.x-gpu:
 	docker build \
 		-t systemsgenetics/kinc:3.4.2-gpu \
 		--build-arg NVIDIA_HEADLESS=0 \
@@ -32,13 +61,17 @@ v3.4.x:
 		--build-arg KINC_R_REVISION=v1.2 \
 		.
 
-v3.3.x:
+v3.3.x: v3.3.x-cpu v3.3.x-gpu
+
+v3.3.x-cpu:
 	docker build \
 		-t systemsgenetics/kinc:3.3.0-cpu \
 		--build-arg NVIDIA_HEADLESS=1 \
 		--build-arg ACE_REVISION=v3.1.0 \
 		--build-arg KINC_REVISION=v3.3.0 \
 		.
+
+v3.3.x-gpu:
 	docker build \
 		-t systemsgenetics/kinc:3.3.0-gpu \
 		--build-arg NVIDIA_HEADLESS=0 \
@@ -55,6 +88,8 @@ v3.2.x:
 		.
 
 push:
+	docker push systemsgenetics/kinc:develop-cpu
+	docker push systemsgenetics/kinc:develop-gpu
 	docker push systemsgenetics/kinc:latest-cpu
 	docker push systemsgenetics/kinc:latest-gpu
 	docker push systemsgenetics/kinc:3.4.2-cpu
@@ -64,6 +99,8 @@ push:
 	docker push systemsgenetics/kinc:3.2.2
 
 pull:
+	docker pull systemsgenetics/kinc:develop-cpu
+	docker pull systemsgenetics/kinc:develop-gpu
 	docker pull systemsgenetics/kinc:latest-cpu
 	docker pull systemsgenetics/kinc:latest-gpu
 	docker pull systemsgenetics/kinc:3.4.2-cpu
@@ -73,6 +110,8 @@ pull:
 	docker pull systemsgenetics/kinc:3.2.2
 
 clean:
+	docker image rm -f systemsgenetics/kinc:develop-cpu
+	docker image rm -f systemsgenetics/kinc:develop-gpu
 	docker image rm -f systemsgenetics/kinc:latest-cpu
 	docker image rm -f systemsgenetics/kinc:latest-gpu
 	docker image rm -f systemsgenetics/kinc:3.4.2-cpu

--- a/docker/Makefile
+++ b/docker/Makefile
@@ -3,14 +3,14 @@ all: latest v3.4.x v3.3.x v3.2.x
 latest:
 	docker build \
 		-t systemsgenetics/kinc:latest-cpu \
-		--build-arg NVIDIA_HEADLESS=0 \
+		--build-arg NVIDIA_HEADLESS=1 \
 		--build-arg ACE_REVISION=v3.2.0 \
 		--build-arg KINC_REVISION=develop \
 		--build-arg KINC_R_REVISION=v1.2 \
 		.
 	docker build \
 		-t systemsgenetics/kinc:latest-gpu \
-		--build-arg NVIDIA_HEADLESS=1 \
+		--build-arg NVIDIA_HEADLESS=0 \
 		--build-arg ACE_REVISION=v3.2.0 \
 		--build-arg KINC_REVISION=develop \
 		--build-arg KINC_R_REVISION=v1.2 \
@@ -19,14 +19,14 @@ latest:
 v3.4.x:
 	docker build \
 		-t systemsgenetics/kinc:3.4.2-cpu \
-		--build-arg NVIDIA_HEADLESS=0 \
+		--build-arg NVIDIA_HEADLESS=1 \
 		--build-arg ACE_REVISION=v3.2.0 \
 		--build-arg KINC_REVISION=v3.4.2 \
 		--build-arg KINC_R_REVISION=v1.2 \
 		.
 	docker build \
 		-t systemsgenetics/kinc:3.4.2-gpu \
-		--build-arg NVIDIA_HEADLESS=1 \
+		--build-arg NVIDIA_HEADLESS=0 \
 		--build-arg ACE_REVISION=v3.2.0 \
 		--build-arg KINC_REVISION=v3.4.2 \
 		--build-arg KINC_R_REVISION=v1.2 \
@@ -35,13 +35,13 @@ v3.4.x:
 v3.3.x:
 	docker build \
 		-t systemsgenetics/kinc:3.3.0-cpu \
-		--build-arg NVIDIA_HEADLESS=0 \
+		--build-arg NVIDIA_HEADLESS=1 \
 		--build-arg ACE_REVISION=v3.1.0 \
 		--build-arg KINC_REVISION=v3.3.0 \
 		.
 	docker build \
 		-t systemsgenetics/kinc:3.3.0-gpu \
-		--build-arg NVIDIA_HEADLESS=1 \
+		--build-arg NVIDIA_HEADLESS=0 \
 		--build-arg ACE_REVISION=v3.1.0 \
 		--build-arg KINC_REVISION=v3.3.0 \
 		.
@@ -49,7 +49,7 @@ v3.3.x:
 v3.2.x:
 	docker build \
 		-t systemsgenetics/kinc:3.2.2 \
-		--build-arg NVIDIA_HEADLESS=0 \
+		--build-arg NVIDIA_HEADLESS=1 \
 		--build-arg ACE_REVISION=v3.0.2 \
 		--build-arg KINC_REVISION=v3.2.2 \
 		.

--- a/docker/Makefile
+++ b/docker/Makefile
@@ -3,45 +3,45 @@ all: latest v3.4.x v3.3.x v3.2.x
 latest:
 	docker build \
 		-t systemsgenetics/kinc:latest-cpu \
-		--build-arg NVIDIA_HEADLESS=1 \
-		--build-arg ACE_REVISION=v3.2.0 \
-		--build-arg KINC_REVISION=develop \
-		--build-arg KINC_R_REVISION=1.2 \
-		.
-	docker build \
-		-t systemsgenetics/kinc:latest-gpu \
 		--build-arg NVIDIA_HEADLESS=0 \
 		--build-arg ACE_REVISION=v3.2.0 \
 		--build-arg KINC_REVISION=develop \
-		--build-arg KINC_R_REVISION=1.2 \
+		--build-arg KINC_R_REVISION=v1.2 \
+		.
+	docker build \
+		-t systemsgenetics/kinc:latest-gpu \
+		--build-arg NVIDIA_HEADLESS=1 \
+		--build-arg ACE_REVISION=v3.2.0 \
+		--build-arg KINC_REVISION=develop \
+		--build-arg KINC_R_REVISION=v1.2 \
 		.
 
 v3.4.x:
 	docker build \
 		-t systemsgenetics/kinc:3.4.2-cpu \
-		--build-arg NVIDIA_HEADLESS=1 \
-		--build-arg ACE_REVISION=v3.2.0 \
-		--build-arg KINC_REVISION=docker-update \
-		--build-arg KINC_R_REVISION=1.2 \
-		.
-	docker build \
-		-t systemsgenetics/kinc:3.4.2-gpu \
 		--build-arg NVIDIA_HEADLESS=0 \
 		--build-arg ACE_REVISION=v3.2.0 \
 		--build-arg KINC_REVISION=docker-update \
-		--build-arg KINC_R_REVISION=1.2 \
+		--build-arg KINC_R_REVISION=v1.2 \
+		.
+	docker build \
+		-t systemsgenetics/kinc:3.4.2-gpu \
+		--build-arg NVIDIA_HEADLESS=1 \
+		--build-arg ACE_REVISION=v3.2.0 \
+		--build-arg KINC_REVISION=docker-update \
+		--build-arg KINC_R_REVISION=v1.2 \
 		.
 
 v3.3.x:
 	docker build \
 		-t systemsgenetics/kinc:3.3.0-cpu \
-		--build-arg NVIDIA_HEADLESS=1 \
+		--build-arg NVIDIA_HEADLESS=0 \
 		--build-arg ACE_REVISION=v3.1.0 \
 		--build-arg KINC_REVISION=v3.3.0 \
 		.
 	docker build \
 		-t systemsgenetics/kinc:3.3.0-gpu \
-		--build-arg NVIDIA_HEADLESS=0 \
+		--build-arg NVIDIA_HEADLESS=1 \
 		--build-arg ACE_REVISION=v3.1.0 \
 		--build-arg KINC_REVISION=v3.3.0 \
 		.

--- a/docker/Makefile
+++ b/docker/Makefile
@@ -21,14 +21,14 @@ v3.4.x:
 		-t systemsgenetics/kinc:3.4.2-cpu \
 		--build-arg NVIDIA_HEADLESS=0 \
 		--build-arg ACE_REVISION=v3.2.0 \
-		--build-arg KINC_REVISION=docker-update \
+		--build-arg KINC_REVISION=v3.4.2 \
 		--build-arg KINC_R_REVISION=v1.2 \
 		.
 	docker build \
 		-t systemsgenetics/kinc:3.4.2-gpu \
 		--build-arg NVIDIA_HEADLESS=1 \
 		--build-arg ACE_REVISION=v3.2.0 \
-		--build-arg KINC_REVISION=docker-update \
+		--build-arg KINC_REVISION=v3.4.2 \
 		--build-arg KINC_R_REVISION=v1.2 \
 		.
 

--- a/docker/Makefile
+++ b/docker/Makefile
@@ -6,12 +6,14 @@ latest:
 		--build-arg NVIDIA_HEADLESS=1 \
 		--build-arg ACE_REVISION=v3.2.0 \
 		--build-arg KINC_REVISION=develop \
+		--build-arg KINC_R_REVISION=1.2 \
 		.
 	docker build \
 		-t systemsgenetics/kinc:latest-gpu \
 		--build-arg NVIDIA_HEADLESS=0 \
 		--build-arg ACE_REVISION=v3.2.0 \
-		--build-arg KINC_REVISION=docker-update \
+		--build-arg KINC_REVISION=develop \
+		--build-arg KINC_R_REVISION=1.2 \
 		.
 
 v3.4.x:
@@ -19,13 +21,15 @@ v3.4.x:
 		-t systemsgenetics/kinc:3.4.2-cpu \
 		--build-arg NVIDIA_HEADLESS=1 \
 		--build-arg ACE_REVISION=v3.2.0 \
-		--build-arg KINC_REVISION=develop \
+		--build-arg KINC_REVISION=docker-update \
+		--build-arg KINC_R_REVISION=1.2 \
 		.
 	docker build \
 		-t systemsgenetics/kinc:3.4.2-gpu \
 		--build-arg NVIDIA_HEADLESS=0 \
 		--build-arg ACE_REVISION=v3.2.0 \
-		--build-arg KINC_REVISION=develop \
+		--build-arg KINC_REVISION=docker-update \
+		--build-arg KINC_R_REVISION=1.2 \
 		.
 
 v3.3.x:

--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -518,16 +518,28 @@ This solution does require installation of `Docker <https://www.docker.com/>`_ w
 
 The KINC docker image comes pre-installed with all dependencies. The Dockerfile for KINC is available in the KINC Github repository, and Docker images are maintained on DockerHub under ``systemsgenetics/kinc``. This method currently does not support the GUI version of KINC.
 
-To use KINC in an interactive Docker container execute the following:
+Interactive Mode
+````````````````
+To use KINC in an interactive Docker container **with GPUs** execute the following:
 
+
+.. code:: bash
+
+  docker run --gpus all --rm -it --net=host -v ${PWD}:/workspace -u $(id -u ${USER})  systemsgenetics/kinc:3.4.2-gpu /bin/bash
+
+The command above will provide access to the terminal inside of the `systemsgenetics/kinc:3.4.2-gpu` image.
+
+To use KINC in an interactive Docker container **without GPUs** execute the following:
 
 .. code:: bash
 
   docker run --gpus all --rm -it --net=host -v ${PWD}:/workspace -u $(id -u ${USER})  systemsgenetics/kinc:3.4.2-cpu /bin/bash
 
-The command above will provide access to the terminal inside of the image. The following describes the meaning of each argument:
+The above command uses the image `systemsgenetics/kinc:3.4.2-cpu` (note the "-cpu" suffix).
 
-- `--gpus all`:  ensures that the NVidia CUDA libraries are present in the image.
+The following describes the meaning of each argument in the commands above:
+
+- `--gpus all`:  ensures that the NVidia CUDA libraries are present in the image. This is needed even if using only CPUs.
 - `--rm`:  will cause the container to be cleaned up after you exit.
 - `--it`:  tells Docker to run in interactive mode with a terminal
 - `--net=host`:  exposes network ports in the image to your local machine. This is needed to use the Docker image for the 3D KINC viewer.
@@ -541,6 +553,9 @@ Once inside the KINC Docker image you can execute commands such as the following
   > nvidia-smi
   > kinc settings
 
+Test The Example Data
+`````````````````````
+
 To test the docker image using the example data that comes with KINC. Run the following inside of the KINC source directory on your local machine:
 
 .. code:: bash
@@ -551,9 +566,34 @@ Next run the following commands inside of the container:
 
 .. code:: bash
 
-  cd /worspace/examples
+  cd /workspace/example
   ./kinc-gmm-run.sh
 
+Using the 3D Visualization Tool
+```````````````````````````````
+To use the 3D visaulization tool to explore a KINC created network first start an interactive session in the directory where the network file(s) are stored:
+
+.. code:: bash
+
+  docker run --gpus all --rm -it --net=host -v ${PWD}:/workspace -u $(id -u ${USER})  systemsgenetics/kinc:3.4.2-cpu /bin/bash
+
+Then  run the `kinc-3d-viewer.py`.  For example, if the example data is already fully processed using the steps in the previous section you can view the results with the viewer with the following commands.
+
+.. code:: bash
+
+  cd /workspace/example/results-kinc-gmm-run
+  kinc-3d-viewer.py \
+    --net "PRJNA301554.slim.GEM.log2.paf-th0.00-p1e-3-rsqr0.30-filtered-th_ranked.csGCN.txt" \
+    --emx "../data/PRJNA301554.slim.GEM.log2.txt" \
+    --amx "../data/PRJNA301554.slim.annotations.txt"
+
+The first time the viewer is run you will see output about creating 2D and 3D layouts. Once completed you will see a line of text similar to the following:
+
+.. code::
+
+    * Running on http://127.0.0.1:8050/ (Press CTRL+C to quit)
+
+Copy the URL into a web browser and view the network.
 
 Automating KINC with Nextflow
 -----------------------------

--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -520,23 +520,40 @@ The KINC docker image comes pre-installed with all dependencies. The Dockerfile 
 
 To use KINC in an interactive Docker container execute the following:
 
+
 .. code:: bash
 
-  nvidia-docker run --rm -it systemsgenetics/kinc:3.4.2 bash
+  docker run --gpus all --rm -it --net=host -v ${PWD}:/workspace -u $(id -u ${USER})  systemsgenetics/kinc:3.4.2-cpu /bin/bash
 
-The command above will provide access to the terminal inside of the image where commands such as the following can be executed:
+The command above will provide access to the terminal inside of the image. The following describes the meaning of each argument:
+
+- `--gpus all`:  ensures that the NVidia CUDA libraries are present in the image.
+- `--rm`:  will cause the container to be cleaned up after you exit.
+- `--it`:  tells Docker to run in interactive mode with a terminal
+- `--net=host`:  exposes network ports in the image to your local machine. This is needed to use the Docker image for the 3D KINC viewer.
+- `-v ${PWD}:/workspace`: adds the current directory on the local machine as a filesystem in the image accessible via `/workspace`.  This allows you to work with files on your local machine inside of the image.
+- `-u $(id -u ${USER})`:  logs you in as your local user account so that any files created within directories mounted by the image are saved with your user account.
+
+Once inside the KINC Docker image you can execute commands such as the following:
 
 .. code:: bash
 
   > nvidia-smi
   > kinc settings
 
-You will need to share the input and output data between the Docker container and the host machine, which can be done by mounting a directory with the ``-v`` argument.  The example below mounts the current directory specified by the `$PWD` environment variable onto the `/root` directory of the image:
+To test the docker image using the example data that comes with KINC. Run the following inside of the KINC source directory on your local machine:
 
 .. code:: bash
 
-  nvidia-docker run --rm -it -v $PWD:/root systemsgenetics/kinc:3.4.2 bash
-  > ls
+  docker run --gpus all --rm -it --net=host -v ${PWD}:/workspace -u $(id -u ${USER})  systemsgenetics/kinc:3.4.2-cpu /bin/bash
+
+Next run the following commands inside of the container:
+
+.. code:: bash
+
+  cd /worspace/examples
+  ./kinc-gmm-run.sh
+
 
 Automating KINC with Nextflow
 -----------------------------

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,3 +4,10 @@ numpy
 pandas
 scipy
 seaborn
+igraph
+plotly
+fa2
+dash
+dash_core_components
+dash_html_components
+progress.bar

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,10 +4,8 @@ numpy
 pandas
 scipy
 seaborn
-igraph
+python-igraph
 plotly
 fa2
 dash
-dash_core_components
-dash_html_components
-progress.bar
+progress


### PR DESCRIPTION
This PR updates the Docker file to support the RScripts and the 3D python viewer so that users who want to use the Docker image to avoid installing all of the dependencies can do so.  

This PR makes the following changes:
- In the Makefile:
  - the `lastest` images now have ACE hardcoded to 3.2.0 rather than `develop`. This is because the develop branch can have, at any point in time, experimental code.  I think the `latest` image should be the latest of development version of KINC and not the latest of of ACE.
  - I changed the NVIDIA_HEADLESS option to be consistent between the cpu and gpu tagged images.
  - I added a new KINC_R_REVISION argument.
- In the Dockerfile
  - I updated section to behave differently for newer version of KINC. For example in 3.4.2 we have a much simplified make procedure that if not used does not install the scripts in the bin folder.
  - I added installation of R, KINC.R
- In the Documentation 
  - I adjust the text to reflect the new additions for the docker images. However, I'm not 100% sure when to tell the user to use the `-cpu` and `-gpu` tagged images.  That should be included as the current image name isn't correct in the commands.
   - I changed the docker command from `nvidia-docker` to just `docker` with the `--gpus all` option.  I wasn't able to run the image with `nvidia-docker` as that didn't exist on my machine.

Unfortunately, all of these changes makes the image rather large and take a long time to build.