### PR TITLE
Filtering by rank, top_n argument is confusing

### DIFF
--- a/bin/kinc-filter-rank.R
+++ b/bin/kinc-filter-rank.R
@@ -10,7 +10,7 @@ option_list = list(
               help="(optional). The file name prefix used for the ouput files. If this arugment is not provided then the original network file name is used as a prefix.",
               metavar="character"),
    make_option(c("--top_n"), type="numeric", default=10000,
-              help="(optional). Extract the top n ranked edges from the network file. This is the top n ranked edges per condition. If --no_conditions is provided then this is the top n ranked edges in the full network. Note: some edges may have the same rank and you will recieve all edges whose rank meets the given criteria.",
+              help="(optional). Extract the top n ranked edges from the network file. This is the top n ranked edges per condition. If --no_conditions is provided then this is the top n ranked edges in the full network. Note: some edges may have the same rank, but only the first top_n will be returned.",
               metavar="numeric"),
    make_option(c("--no_condition_rankings"), type="logical", action="store_true",
               help="(optional). By deafult the rankings are calculated independently per each condition in the network. To calculate rankings for the entire network regardless of condition set this to TRUE.",
@@ -57,6 +57,7 @@ if(packageVersion("KINC.R") < "1.1") {
     stop("This script requires KINC.R > 1.1")
 }
 suppressMessages(library("KINC.R"))
+suppressMessages(library("dplyr"))
 
 message("")
 message(' __  __   ______   __  __  ____       ____        ')
@@ -70,32 +71,49 @@ message("")
 message("This script uses KINC.R, a companion R library for KINC")
 message("https://github.com/SystemsGenetics/KINC.R")
 message("-------------------------------------------------------")
-message("Loading the KINC network file...")
 
-net = loadKINCNetwork(opt$net)
 
 # Get the edge ranks.
-ranks = c()
-if (opt$no_condition_rankings) {
-    message("Calculating network-wide ranks...")
-    ranks = getEdgeRanks(net, by_condition=FALSE, opt$score_weight, opt$pval_weight, opt$rsqr_weight)
+rdata = paste0(opt$out_prefix, '-th_ranked.RData')
+if (file.exists(rdata)) {
+    message("Reloading previously calculated ranks...")
+    load(rdata)
 } else {
-    message("Calculating condition-specific ranks...")
-    ranks = getEdgeRanks(net, by_condition=TRUE, opt$score_weight, opt$pval_weight, opt$rsqr_weight)
+    message("Loading the KINC network file...")
+
+    net = loadKINCNetwork(opt$net)
+    ranks = c()
+    if (opt$no_condition_rankings) {
+        message("Calculating network-wide ranks...")
+        ranks = getEdgeRanks(net, by_condition=FALSE, opt$score_weight, opt$pval_weight, opt$rsqr_weight)
+    } else {
+        message("Calculating condition-specific ranks...")
+        ranks = getEdgeRanks(net, by_condition=TRUE, opt$score_weight, opt$pval_weight, opt$rsqr_weight)
+    }
+    ranks = as.numeric(ranks)
+    net$rank = ranks
+    save(net, file=rdata)
 }
-ranks = as.numeric(ranks)
-net$rank = ranks
+
 
 # Filter the network to include the top n ranked edges.
-netF = net[(which(ranks < opt$top_n)),]
-netF = netF[order(netF$rank),]
+if (opt$no_condition_rankings) {
+    message(paste("Filtering by top,", opt$top_n, ", network edges..."))
+    net = net[order(net$rank),]
+    netF = net[1:opt$top_n,]
+} else {
+    message(paste("Filtering by top,", opt$top_n, ", conditional edges..."))
+    net = net[order(net$Test_Name, net$rank),]
+    netF = net %>% group_by(Test_Name) %>% slice_head(n=opt$top_n) %>% as.data.frame()
+}
+
 
 if (opt$save_condition_networks) {
-    message("Saving filtered condition-specific networks...")
+    message("Writing filtered condition-specific network files...")
     net_name = paste0(opt$out_prefix, '-th_ranked.%condition%-%filter%.csGCN.txt')
     saveConditionKINCNetwork(netF, net_name, filter=opt$unique_filter)
 } else {
-    message("Saving filtered network...")
+    message("Writing filtered network file...")
     net_name = paste0(opt$out_prefix, '-th_ranked.csGCN.txt')
     saveKINCNetwork(netF, net_name)
 }

--- a/example/kinc-gmm-chunkrun.sh
+++ b/example/kinc-gmm-chunkrun.sh
@@ -126,22 +126,22 @@ echo "Generating condition-specific network files by class and label."
 kinc-filter-rank.R \
     --net "PRJNA301554.slim.GEM.log2.paf-th0.00-p1e-3-rsqr0.30-filtered.GCN.txt" \
     --out_prefix "PRJNA301554.slim.GEM.log2.paf-th0.00-p1e-3-rsqr0.30-filtered" \
-    --top_n 26035
+    --top_n 25000
 
 kinc-filter-rank.R \
     --net "PRJNA301554.slim.GEM.log2.paf-th0.00-p1e-3-rsqr0.30-filtered.GCN.txt" \
     --out_prefix "PRJNA301554.slim.GEM.log2.paf-th0.00-p1e-3-rsqr0.30-filtered" \
     --save_condition_networks \
-    --top_n 26035
+    --top_n 25000
 
 kinc-filter-rank.R \
     --net "PRJNA301554.slim.GEM.log2.paf-th0.00-p1e-3-rsqr0.30-filtered.GCN.txt" \
     --out_prefix "PRJNA301554.slim.GEM.log2.paf-th0.00-p1e-3-rsqr0.30-filtered" \
     --save_condition_networks --unique_filter "label" \
-    --top_n 26035
+    --top_n 25000
 
 kinc-filter-rank.R \
     --net "PRJNA301554.slim.GEM.log2.paf-th0.00-p1e-3-rsqr0.30-filtered.GCN.txt" \
     --out_prefix "PRJNA301554.slim.GEM.log2.paf-th0.00-p1e-3-rsqr0.30-filtered" \
     --save_condition_networks --unique_filter "class" \
-    --top_n 26035
+    --top_n 25000

--- a/example/kinc-gmm-mpirun.sh
+++ b/example/kinc-gmm-mpirun.sh
@@ -105,22 +105,22 @@ echo "Generating condition-specific network files by class and label."
 kinc-filter-rank.R \
     --net "PRJNA301554.slim.GEM.log2.paf-th0.00-p1e-3-rsqr0.30-filtered.GCN.txt" \
     --out_prefix "PRJNA301554.slim.GEM.log2.paf-th0.00-p1e-3-rsqr0.30-filtered" \
-    --top_n 26035
+    --top_n 25000
 
 kinc-filter-rank.R \
     --net "PRJNA301554.slim.GEM.log2.paf-th0.00-p1e-3-rsqr0.30-filtered.GCN.txt" \
     --out_prefix "PRJNA301554.slim.GEM.log2.paf-th0.00-p1e-3-rsqr0.30-filtered" \
     --save_condition_networks \
-    --top_n 26035
+    --top_n 25000
 
 kinc-filter-rank.R \
     --net "PRJNA301554.slim.GEM.log2.paf-th0.00-p1e-3-rsqr0.30-filtered.GCN.txt" \
     --out_prefix "PRJNA301554.slim.GEM.log2.paf-th0.00-p1e-3-rsqr0.30-filtered" \
     --save_condition_networks --unique_filter "label" \
-    --top_n 26035
+    --top_n 25000
 
 kinc-filter-rank.R \
     --net "PRJNA301554.slim.GEM.log2.paf-th0.00-p1e-3-rsqr0.30-filtered.GCN.txt" \
     --out_prefix "PRJNA301554.slim.GEM.log2.paf-th0.00-p1e-3-rsqr0.30-filtered" \
     --save_condition_networks --unique_filter "class" \
-    --top_n 26035
+    --top_n 25000

--- a/example/kinc-gmm-run.sh
+++ b/example/kinc-gmm-run.sh
@@ -102,22 +102,22 @@ echo "Generating condition-specific network files by class and label."
 kinc-filter-rank.R \
     --net "PRJNA301554.slim.GEM.log2.paf-th0.00-p1e-3-rsqr0.30-filtered.GCN.txt" \
     --out_prefix "PRJNA301554.slim.GEM.log2.paf-th0.00-p1e-3-rsqr0.30-filtered" \
-    --top_n 20000
+    --top_n 25000
 
 kinc-filter-rank.R \
     --net "PRJNA301554.slim.GEM.log2.paf-th0.00-p1e-3-rsqr0.30-filtered.GCN.txt" \
     --out_prefix "PRJNA301554.slim.GEM.log2.paf-th0.00-p1e-3-rsqr0.30-filtered" \
     --save_condition_networks \
-    --top_n 20000
+    --top_n 25000
 
 kinc-filter-rank.R \
     --net "PRJNA301554.slim.GEM.log2.paf-th0.00-p1e-3-rsqr0.30-filtered.GCN.txt" \
     --out_prefix "PRJNA301554.slim.GEM.log2.paf-th0.00-p1e-3-rsqr0.30-filtered" \
     --save_condition_networks --unique_filter "label" \
-    --top_n 20000
+    --top_n 25000
 
 kinc-filter-rank.R \
     --net "PRJNA301554.slim.GEM.log2.paf-th0.00-p1e-3-rsqr0.30-filtered.GCN.txt" \
     --out_prefix "PRJNA301554.slim.GEM.log2.paf-th0.00-p1e-3-rsqr0.30-filtered" \
     --save_condition_networks --unique_filter "class" \
-    --top_n 20000
+    --top_n 25000

--- a/example/kinc-gmm-run.sh
+++ b/example/kinc-gmm-run.sh
@@ -102,22 +102,22 @@ echo "Generating condition-specific network files by class and label."
 kinc-filter-rank.R \
     --net "PRJNA301554.slim.GEM.log2.paf-th0.00-p1e-3-rsqr0.30-filtered.GCN.txt" \
     --out_prefix "PRJNA301554.slim.GEM.log2.paf-th0.00-p1e-3-rsqr0.30-filtered" \
-    --top_n 26035
+    --top_n 20000
 
 kinc-filter-rank.R \
     --net "PRJNA301554.slim.GEM.log2.paf-th0.00-p1e-3-rsqr0.30-filtered.GCN.txt" \
     --out_prefix "PRJNA301554.slim.GEM.log2.paf-th0.00-p1e-3-rsqr0.30-filtered" \
     --save_condition_networks \
-    --top_n 26035
+    --top_n 20000
 
 kinc-filter-rank.R \
     --net "PRJNA301554.slim.GEM.log2.paf-th0.00-p1e-3-rsqr0.30-filtered.GCN.txt" \
     --out_prefix "PRJNA301554.slim.GEM.log2.paf-th0.00-p1e-3-rsqr0.30-filtered" \
     --save_condition_networks --unique_filter "label" \
-    --top_n 26035
+    --top_n 20000
 
 kinc-filter-rank.R \
     --net "PRJNA301554.slim.GEM.log2.paf-th0.00-p1e-3-rsqr0.30-filtered.GCN.txt" \
     --out_prefix "PRJNA301554.slim.GEM.log2.paf-th0.00-p1e-3-rsqr0.30-filtered" \
     --save_condition_networks --unique_filter "class" \
-    --top_n 26035
+    --top_n 20000


### PR DESCRIPTION
# Issue
This fixes issue #155 raised by @JohnHadish.  Previously, the `top_n` argument of the `kinc-filter-rank.R` script retrieved all edges that have a rank less than or equal to the specified `top_n` argument. Because edges can have the same rank this meant you would sometimes get a lot more edges than you bargained for and would make working with the resulting network difficult if it was bigger than you expected.  

# The Fix
This PR adjust the script so that the actual number of edges specified by `top_n` are returned.  So for example, if you set a `top_n` of 20000 then the top 20,000 edges for each condition will be returned.  

Also, the `kinc-filter-rank.R` script has a nice update with this PR, in that if it saves the ranked network in an .RData file so that each time you run it, it no longer has to calculate the ranks each time.  That saves a lot of time.  

You have to have `dplyr` >= 1.0.0 or you might get an error about `splice_head` not being found. If you get the error, just update `dplyr` in R.

# How to Test
To test, run the example data. using the `kinc-gmm-run.sh` script.  Then go into the results directory and run the following to retrieve all edges.

```
kinc-filter-rank.R \
    --net "PRJNA301554.slim.GEM.log2.paf-th0.00-p1e-3-rsqr0.30-filtered.GCN.txt" \
    --out_prefix "PRJNA301554.slim.GEM.log2.paf-th0.00-p1e-3-rsqr0.30-filtered" \
    --top_n 20000

kinc-filter-rank.R \
    --net "PRJNA301554.slim.GEM.log2.paf-th0.00-p1e-3-rsqr0.30-filtered.GCN.txt" \
    --out_prefix "PRJNA301554.slim.GEM.log2.paf-th0.00-p1e-3-rsqr0.30-filtered" \
    --save_condition_networks \
    --top_n 20000

kinc-filter-rank.R \
    --net "PRJNA301554.slim.GEM.log2.paf-th0.00-p1e-3-rsqr0.30-filtered.GCN.txt" \
    --out_prefix "PRJNA301554.slim.GEM.log2.paf-th0.00-p1e-3-rsqr0.30-filtered" \
    --save_condition_networks --unique_filter "label" \
    --top_n 20000

kinc-filter-rank.R \
    --net "PRJNA301554.slim.GEM.log2.paf-th0.00-p1e-3-rsqr0.30-filtered.GCN.txt" \
    --out_prefix "PRJNA301554.slim.GEM.log2.paf-th0.00-p1e-3-rsqr0.30-filtered" \
    --save_condition_networks --unique_filter "class" \
    --top_n 20000
```

The run the following to just get 20 edges:
```
kinc-filter-rank.R \
    --net "PRJNA301554.slim.GEM.log2.paf-th0.00-p1e-3-rsqr0.30-filtered.GCN.txt" \
    --out_prefix "PRJNA301554.slim.GEM.log2.paf-th0.00-p1e-3-rsqr0.30-filtered" \
    --top_n 20

kinc-filter-rank.R \
    --net "PRJNA301554.slim.GEM.log2.paf-th0.00-p1e-3-rsqr0.30-filtered.GCN.txt" \
    --out_prefix "PRJNA301554.slim.GEM.log2.paf-th0.00-p1e-3-rsqr0.30-filtered" \
    --save_condition_networks \
    --top_n 20

kinc-filter-rank.R \
    --net "PRJNA301554.slim.GEM.log2.paf-th0.00-p1e-3-rsqr0.30-filtered.GCN.txt" \
    --out_prefix "PRJNA301554.slim.GEM.log2.paf-th0.00-p1e-3-rsqr0.30-filtered" \
    --save_condition_networks --unique_filter "label" \
    --top_n 20

kinc-filter-rank.R \
    --net "PRJNA301554.slim.GEM.log2.paf-th0.00-p1e-3-rsqr0.30-filtered.GCN.txt" \
    --out_prefix "PRJNA301554.slim.GEM.log2.paf-th0.00-p1e-3-rsqr0.30-filtered" \
    --save_condition_networks --unique_filter "class" \
    --top_n 20
```

Look at the resulting files and you should in the second run only 20 edges per condition (at most, less if fewer than that existed).  